### PR TITLE
Add support for reading CSV files from Binance

### DIFF
--- a/csv-reader/src/binance/binance.test.ts
+++ b/csv-reader/src/binance/binance.test.ts
@@ -1,0 +1,106 @@
+import test from "ava"
+import { Temporal } from "proposal-temporal"
+import { ExecutionContext } from "ava"
+import { readBuySellCsv, readTradeCsv } from "./binance"
+
+const BINANCE_TRADE_HEADER =
+  "Date(UTC);Market;Type;Price;Amount;Total;Fee;Fee Coin"
+const BINANCE_BUYSELL_HEADER =
+  "Date(UTC);Method;Amount;Price;Fees;Final Amount;Status;Transaction ID"
+
+const toCsv = (header: string, ...rows: string[]) =>
+  [header].concat(rows).join("\r\n").concat("\r\n")
+
+test("Empty report", (t) => {
+  t.deepEqual(readTradeCsv(toCsv(BINANCE_TRADE_HEADER)), [])
+})
+
+test("TRADE: Sell BTC for USDT", (t) => {
+  eq(
+    t,
+    readTradeCsv(
+      toCsv(
+        BINANCE_TRADE_HEADER,
+        `2021-10-03 13:53:53;BTCUSDT;SELL;48096.6;0.00043;20.681538;0.02068154;USDT`
+      )
+    ),
+    [
+      {
+        id: "binance_trade_2021-10-03T13:53:53",
+        date: Temporal.PlainDate.from("2021-10-03"),
+        from: { symbol: "BTC", amount: 0.00043 },
+        to: { symbol: "USDT", amount: 20.681538 },
+        fee: { symbol: "USDT", amount: 0.02068154 },
+      },
+    ]
+  )
+})
+
+test("TRADE: Sell LTC for BTC", (t) => {
+  eq(
+    t,
+    readTradeCsv(
+      toCsv(
+        BINANCE_TRADE_HEADER,
+        `2021-10-03 13:32:06;LTCBTC;SELL;0.00001078;5;0.0000539;0.00000005;BTC`
+      )
+    ),
+    [
+      {
+        id: "binance_trade_2021-10-03T13:32:06",
+        date: Temporal.PlainDate.from("2021-10-03"),
+        from: { symbol: "LTC", amount: 5 },
+        to: { symbol: "BTC", amount: 0.0000539 },
+        fee: { symbol: "BTC", amount: 0.00000005 },
+      },
+    ]
+  )
+})
+
+test("TRADE: Buy LTC with BTC", (t) => {
+  eq(
+    t,
+    readTradeCsv(
+      toCsv(
+        BINANCE_TRADE_HEADER,
+        `2021-10-03 13:09:07;LTCBTC;BUY;0.00001085;20;0.000217;0.02;LTC`
+      )
+    ),
+    [
+      {
+        id: "binance_trade_2021-10-03T13:09:07",
+        date: Temporal.PlainDate.from("2021-10-03"),
+        from: { symbol: "BTC", amount: 0.000217 },
+        to: { symbol: "LTC", amount: 20 },
+        fee: { symbol: "LTC", amount: 0.02 },
+      },
+    ]
+  )
+})
+
+test("BUY: Buy BTC with EUR", (t) => {
+  eq(
+    t,
+    readBuySellCsv(
+      toCsv(
+        BINANCE_BUYSELL_HEADER,
+        `2021-10-03 11:31:19;Cash Balance;49.10 EUR;41266.053 BTC/EUR;0.00 EUR;0.00118984 BTC;Completed;foobarbazidentifier`
+      )
+    ),
+    [
+      {
+        id: "binance_buysell_foobarbazidentifier",
+        date: Temporal.PlainDate.from("2021-10-03"),
+        from: { symbol: "EUR", amount: 49.1 },
+        to: { symbol: "BTC", amount: 0.00118984 },
+        fee: { symbol: "EUR", amount: 0.0 },
+      },
+    ]
+  )
+})
+
+export const eq = <T>(t: ExecutionContext<unknown>, left: T, right: T) =>
+  t.deepEqual(
+    JSON.parse(JSON.stringify(left)),
+    JSON.parse(JSON.stringify(right))
+  )

--- a/csv-reader/src/binance/binance.ts
+++ b/csv-reader/src/binance/binance.ts
@@ -1,0 +1,113 @@
+import { Temporal } from "proposal-temporal"
+import { Ledger, LedgerItem } from "@fifo/ledger"
+import * as B from "@fifo/csv-reader/src/binance/markets-symbols"
+
+// Note:
+// Binance has separate export mechanisms for trades and crypto bought/sold with fiat currency,
+// And the CSV header is different for each.
+
+const COLUMN_DELIMITER = ";"
+
+export function readTradeCsv(input: string): Ledger {
+  return input
+    .split("\r\n")
+    .slice(1)
+    .filter((row) => row.trim())
+    .map((row) => parseTradeRow(row.split(COLUMN_DELIMITER)))
+    .map((row): LedgerItem => {
+      const marketInfo = B.BINANCE_MARKETS[row.market as B.BinanceMarket]
+      const [fromSymbol, toSymbol] =
+        row.type === "BUY"
+          ? [marketInfo.quoteAsset, marketInfo.baseAsset]
+          : [marketInfo.baseAsset, marketInfo.quoteAsset]
+      const [fromAmount, toAmount] =
+        row.type === "BUY" ? [row.total, row.amount] : [row.amount, row.total]
+      const fromUnitPriceEur = row.type === "BUY" ? 1 : row.price
+      const toUnitPriceEur = row.type === "BUY" ? row.price : 1
+      return {
+        id: `binance_trade_${row.createdAt.toString()}`,
+        date: row.createdAt.toPlainDate(),
+        from: {
+          symbol: fromSymbol,
+          amount: fromAmount,
+          unitPriceEur: row.feeCoin === "EUR" ? fromUnitPriceEur : undefined,
+        },
+        to: {
+          symbol: toSymbol,
+          amount: toAmount,
+          unitPriceEur: row.feeCoin === "EUR" ? toUnitPriceEur : undefined,
+        },
+        fee: { amount: row.fee, symbol: row.feeCoin },
+      }
+    })
+}
+
+export function readBuySellCsv(input: string): Ledger {
+  return input
+    .split("\r\n")
+    .slice(1)
+    .filter((row) => row.trim())
+    .map((row) => parseBuySellRow(row.split(COLUMN_DELIMITER)))
+    .map((row): LedgerItem => {
+      // TODO: omitting the unitPriceEurs from this since i'm unsure what's correct.
+      return {
+        id: `binance_buysell_${row.id}`,
+        date: row.createdAt.toPlainDate(),
+        from: {
+          symbol: row.fromCoin,
+          amount: row.fromAmount,
+        },
+        to: {
+          symbol: row.toCoin,
+          amount: row.toAmount,
+        },
+        fee: { amount: row.fee, symbol: row.feeCoin },
+      }
+    })
+}
+
+// Date(UTC);Market;Type;Price;Amount;Total;Fee;Fee Coin
+export function parseTradeRow(strRow: string[]) {
+  const [dateUTC, market, type, price, amount, total, fee, feeCoin] = strRow
+  return {
+    createdAt: Temporal.PlainDateTime.from(dateUTC),
+    market,
+    type: type as "BUY" | "SELL",
+    amount: parseFloat(amount),
+    total: parseFloat(total),
+    price: parseFloat(price),
+    fee: parseFloat(fee),
+    feeCoin,
+  } as const
+}
+
+// Date(UTC);Method;Amount;Price;Fees;Final Amount;Status;Transaction ID
+export function parseBuySellRow(strRow: string[]) {
+  const [
+    dateUTC,
+    method,
+    amount,
+    price,
+    fees,
+    finalAmount,
+    status,
+    transactionId,
+  ] = strRow
+
+  const [fromAmount, fromCoin] = amount.split(" ")
+  const [toAmount, toCoin] = finalAmount.split(" ")
+  const [fee, feeCoin] = fees.split(" ")
+  return {
+    id: transactionId,
+    createdAt: Temporal.PlainDateTime.from(dateUTC),
+    method,
+    status,
+    fromAmount: parseFloat(fromAmount),
+    fromCoin,
+    toAmount: parseFloat(toAmount),
+    toCoin,
+    price: parseFloat(price.split(" ").shift()!),
+    fee: parseFloat(fee),
+    feeCoin,
+  }
+}

--- a/csv-reader/src/binance/markets-symbols.ts
+++ b/csv-reader/src/binance/markets-symbols.ts
@@ -1,0 +1,8403 @@
+// Extracted from Binance API on 2021/10/04
+export const BINANCE_MARKETS = {
+  ETHBTC: {
+    symbol: "ETHBTC",
+    baseAsset: "ETH",
+    quoteAsset: "BTC",
+  },
+  LTCBTC: {
+    symbol: "LTCBTC",
+    baseAsset: "LTC",
+    quoteAsset: "BTC",
+  },
+  BNBBTC: {
+    symbol: "BNBBTC",
+    baseAsset: "BNB",
+    quoteAsset: "BTC",
+  },
+  NEOBTC: {
+    symbol: "NEOBTC",
+    baseAsset: "NEO",
+    quoteAsset: "BTC",
+  },
+  QTUMETH: {
+    symbol: "QTUMETH",
+    baseAsset: "QTUM",
+    quoteAsset: "ETH",
+  },
+  EOSETH: {
+    symbol: "EOSETH",
+    baseAsset: "EOS",
+    quoteAsset: "ETH",
+  },
+  SNTETH: {
+    symbol: "SNTETH",
+    baseAsset: "SNT",
+    quoteAsset: "ETH",
+  },
+  BNTETH: {
+    symbol: "BNTETH",
+    baseAsset: "BNT",
+    quoteAsset: "ETH",
+  },
+  BCCBTC: {
+    symbol: "BCCBTC",
+    baseAsset: "BCC",
+    quoteAsset: "BTC",
+  },
+  GASBTC: {
+    symbol: "GASBTC",
+    baseAsset: "GAS",
+    quoteAsset: "BTC",
+  },
+  BNBETH: {
+    symbol: "BNBETH",
+    baseAsset: "BNB",
+    quoteAsset: "ETH",
+  },
+  BTCUSDT: {
+    symbol: "BTCUSDT",
+    baseAsset: "BTC",
+    quoteAsset: "USDT",
+  },
+  ETHUSDT: {
+    symbol: "ETHUSDT",
+    baseAsset: "ETH",
+    quoteAsset: "USDT",
+  },
+  HSRBTC: {
+    symbol: "HSRBTC",
+    baseAsset: "HSR",
+    quoteAsset: "BTC",
+  },
+  OAXETH: {
+    symbol: "OAXETH",
+    baseAsset: "OAX",
+    quoteAsset: "ETH",
+  },
+  DNTETH: {
+    symbol: "DNTETH",
+    baseAsset: "DNT",
+    quoteAsset: "ETH",
+  },
+  MCOETH: {
+    symbol: "MCOETH",
+    baseAsset: "MCO",
+    quoteAsset: "ETH",
+  },
+  ICNETH: {
+    symbol: "ICNETH",
+    baseAsset: "ICN",
+    quoteAsset: "ETH",
+  },
+  MCOBTC: {
+    symbol: "MCOBTC",
+    baseAsset: "MCO",
+    quoteAsset: "BTC",
+  },
+  WTCBTC: {
+    symbol: "WTCBTC",
+    baseAsset: "WTC",
+    quoteAsset: "BTC",
+  },
+  WTCETH: {
+    symbol: "WTCETH",
+    baseAsset: "WTC",
+    quoteAsset: "ETH",
+  },
+  LRCBTC: {
+    symbol: "LRCBTC",
+    baseAsset: "LRC",
+    quoteAsset: "BTC",
+  },
+  LRCETH: {
+    symbol: "LRCETH",
+    baseAsset: "LRC",
+    quoteAsset: "ETH",
+  },
+  QTUMBTC: {
+    symbol: "QTUMBTC",
+    baseAsset: "QTUM",
+    quoteAsset: "BTC",
+  },
+  YOYOBTC: {
+    symbol: "YOYOBTC",
+    baseAsset: "YOYO",
+    quoteAsset: "BTC",
+  },
+  OMGBTC: {
+    symbol: "OMGBTC",
+    baseAsset: "OMG",
+    quoteAsset: "BTC",
+  },
+  OMGETH: {
+    symbol: "OMGETH",
+    baseAsset: "OMG",
+    quoteAsset: "ETH",
+  },
+  ZRXBTC: {
+    symbol: "ZRXBTC",
+    baseAsset: "ZRX",
+    quoteAsset: "BTC",
+  },
+  ZRXETH: {
+    symbol: "ZRXETH",
+    baseAsset: "ZRX",
+    quoteAsset: "ETH",
+  },
+  STRATBTC: {
+    symbol: "STRATBTC",
+    baseAsset: "STRAT",
+    quoteAsset: "BTC",
+  },
+  STRATETH: {
+    symbol: "STRATETH",
+    baseAsset: "STRAT",
+    quoteAsset: "ETH",
+  },
+  SNGLSBTC: {
+    symbol: "SNGLSBTC",
+    baseAsset: "SNGLS",
+    quoteAsset: "BTC",
+  },
+  SNGLSETH: {
+    symbol: "SNGLSETH",
+    baseAsset: "SNGLS",
+    quoteAsset: "ETH",
+  },
+  BQXBTC: {
+    symbol: "BQXBTC",
+    baseAsset: "BQX",
+    quoteAsset: "BTC",
+  },
+  BQXETH: {
+    symbol: "BQXETH",
+    baseAsset: "BQX",
+    quoteAsset: "ETH",
+  },
+  KNCBTC: {
+    symbol: "KNCBTC",
+    baseAsset: "KNC",
+    quoteAsset: "BTC",
+  },
+  KNCETH: {
+    symbol: "KNCETH",
+    baseAsset: "KNC",
+    quoteAsset: "ETH",
+  },
+  FUNBTC: {
+    symbol: "FUNBTC",
+    baseAsset: "FUN",
+    quoteAsset: "BTC",
+  },
+  FUNETH: {
+    symbol: "FUNETH",
+    baseAsset: "FUN",
+    quoteAsset: "ETH",
+  },
+  SNMBTC: {
+    symbol: "SNMBTC",
+    baseAsset: "SNM",
+    quoteAsset: "BTC",
+  },
+  SNMETH: {
+    symbol: "SNMETH",
+    baseAsset: "SNM",
+    quoteAsset: "ETH",
+  },
+  NEOETH: {
+    symbol: "NEOETH",
+    baseAsset: "NEO",
+    quoteAsset: "ETH",
+  },
+  IOTABTC: {
+    symbol: "IOTABTC",
+    baseAsset: "IOTA",
+    quoteAsset: "BTC",
+  },
+  IOTAETH: {
+    symbol: "IOTAETH",
+    baseAsset: "IOTA",
+    quoteAsset: "ETH",
+  },
+  LINKBTC: {
+    symbol: "LINKBTC",
+    baseAsset: "LINK",
+    quoteAsset: "BTC",
+  },
+  LINKETH: {
+    symbol: "LINKETH",
+    baseAsset: "LINK",
+    quoteAsset: "ETH",
+  },
+  XVGBTC: {
+    symbol: "XVGBTC",
+    baseAsset: "XVG",
+    quoteAsset: "BTC",
+  },
+  XVGETH: {
+    symbol: "XVGETH",
+    baseAsset: "XVG",
+    quoteAsset: "ETH",
+  },
+  SALTBTC: {
+    symbol: "SALTBTC",
+    baseAsset: "SALT",
+    quoteAsset: "BTC",
+  },
+  SALTETH: {
+    symbol: "SALTETH",
+    baseAsset: "SALT",
+    quoteAsset: "ETH",
+  },
+  MDABTC: {
+    symbol: "MDABTC",
+    baseAsset: "MDA",
+    quoteAsset: "BTC",
+  },
+  MDAETH: {
+    symbol: "MDAETH",
+    baseAsset: "MDA",
+    quoteAsset: "ETH",
+  },
+  MTLBTC: {
+    symbol: "MTLBTC",
+    baseAsset: "MTL",
+    quoteAsset: "BTC",
+  },
+  MTLETH: {
+    symbol: "MTLETH",
+    baseAsset: "MTL",
+    quoteAsset: "ETH",
+  },
+  SUBBTC: {
+    symbol: "SUBBTC",
+    baseAsset: "SUB",
+    quoteAsset: "BTC",
+  },
+  SUBETH: {
+    symbol: "SUBETH",
+    baseAsset: "SUB",
+    quoteAsset: "ETH",
+  },
+  EOSBTC: {
+    symbol: "EOSBTC",
+    baseAsset: "EOS",
+    quoteAsset: "BTC",
+  },
+  SNTBTC: {
+    symbol: "SNTBTC",
+    baseAsset: "SNT",
+    quoteAsset: "BTC",
+  },
+  ETCETH: {
+    symbol: "ETCETH",
+    baseAsset: "ETC",
+    quoteAsset: "ETH",
+  },
+  ETCBTC: {
+    symbol: "ETCBTC",
+    baseAsset: "ETC",
+    quoteAsset: "BTC",
+  },
+  MTHBTC: {
+    symbol: "MTHBTC",
+    baseAsset: "MTH",
+    quoteAsset: "BTC",
+  },
+  MTHETH: {
+    symbol: "MTHETH",
+    baseAsset: "MTH",
+    quoteAsset: "ETH",
+  },
+  ENGBTC: {
+    symbol: "ENGBTC",
+    baseAsset: "ENG",
+    quoteAsset: "BTC",
+  },
+  ENGETH: {
+    symbol: "ENGETH",
+    baseAsset: "ENG",
+    quoteAsset: "ETH",
+  },
+  DNTBTC: {
+    symbol: "DNTBTC",
+    baseAsset: "DNT",
+    quoteAsset: "BTC",
+  },
+  ZECBTC: {
+    symbol: "ZECBTC",
+    baseAsset: "ZEC",
+    quoteAsset: "BTC",
+  },
+  ZECETH: {
+    symbol: "ZECETH",
+    baseAsset: "ZEC",
+    quoteAsset: "ETH",
+  },
+  BNTBTC: {
+    symbol: "BNTBTC",
+    baseAsset: "BNT",
+    quoteAsset: "BTC",
+  },
+  ASTBTC: {
+    symbol: "ASTBTC",
+    baseAsset: "AST",
+    quoteAsset: "BTC",
+  },
+  ASTETH: {
+    symbol: "ASTETH",
+    baseAsset: "AST",
+    quoteAsset: "ETH",
+  },
+  DASHBTC: {
+    symbol: "DASHBTC",
+    baseAsset: "DASH",
+    quoteAsset: "BTC",
+  },
+  DASHETH: {
+    symbol: "DASHETH",
+    baseAsset: "DASH",
+    quoteAsset: "ETH",
+  },
+  OAXBTC: {
+    symbol: "OAXBTC",
+    baseAsset: "OAX",
+    quoteAsset: "BTC",
+  },
+  ICNBTC: {
+    symbol: "ICNBTC",
+    baseAsset: "ICN",
+    quoteAsset: "BTC",
+  },
+  BTGBTC: {
+    symbol: "BTGBTC",
+    baseAsset: "BTG",
+    quoteAsset: "BTC",
+  },
+  BTGETH: {
+    symbol: "BTGETH",
+    baseAsset: "BTG",
+    quoteAsset: "ETH",
+  },
+  EVXBTC: {
+    symbol: "EVXBTC",
+    baseAsset: "EVX",
+    quoteAsset: "BTC",
+  },
+  EVXETH: {
+    symbol: "EVXETH",
+    baseAsset: "EVX",
+    quoteAsset: "ETH",
+  },
+  REQBTC: {
+    symbol: "REQBTC",
+    baseAsset: "REQ",
+    quoteAsset: "BTC",
+  },
+  REQETH: {
+    symbol: "REQETH",
+    baseAsset: "REQ",
+    quoteAsset: "ETH",
+  },
+  VIBBTC: {
+    symbol: "VIBBTC",
+    baseAsset: "VIB",
+    quoteAsset: "BTC",
+  },
+  VIBETH: {
+    symbol: "VIBETH",
+    baseAsset: "VIB",
+    quoteAsset: "ETH",
+  },
+  HSRETH: {
+    symbol: "HSRETH",
+    baseAsset: "HSR",
+    quoteAsset: "ETH",
+  },
+  TRXBTC: {
+    symbol: "TRXBTC",
+    baseAsset: "TRX",
+    quoteAsset: "BTC",
+  },
+  TRXETH: {
+    symbol: "TRXETH",
+    baseAsset: "TRX",
+    quoteAsset: "ETH",
+  },
+  POWRBTC: {
+    symbol: "POWRBTC",
+    baseAsset: "POWR",
+    quoteAsset: "BTC",
+  },
+  POWRETH: {
+    symbol: "POWRETH",
+    baseAsset: "POWR",
+    quoteAsset: "ETH",
+  },
+  ARKBTC: {
+    symbol: "ARKBTC",
+    baseAsset: "ARK",
+    quoteAsset: "BTC",
+  },
+  ARKETH: {
+    symbol: "ARKETH",
+    baseAsset: "ARK",
+    quoteAsset: "ETH",
+  },
+  YOYOETH: {
+    symbol: "YOYOETH",
+    baseAsset: "YOYO",
+    quoteAsset: "ETH",
+  },
+  XRPBTC: {
+    symbol: "XRPBTC",
+    baseAsset: "XRP",
+    quoteAsset: "BTC",
+  },
+  XRPETH: {
+    symbol: "XRPETH",
+    baseAsset: "XRP",
+    quoteAsset: "ETH",
+  },
+  MODBTC: {
+    symbol: "MODBTC",
+    baseAsset: "MOD",
+    quoteAsset: "BTC",
+  },
+  MODETH: {
+    symbol: "MODETH",
+    baseAsset: "MOD",
+    quoteAsset: "ETH",
+  },
+  ENJBTC: {
+    symbol: "ENJBTC",
+    baseAsset: "ENJ",
+    quoteAsset: "BTC",
+  },
+  ENJETH: {
+    symbol: "ENJETH",
+    baseAsset: "ENJ",
+    quoteAsset: "ETH",
+  },
+  STORJBTC: {
+    symbol: "STORJBTC",
+    baseAsset: "STORJ",
+    quoteAsset: "BTC",
+  },
+  STORJETH: {
+    symbol: "STORJETH",
+    baseAsset: "STORJ",
+    quoteAsset: "ETH",
+  },
+  BNBUSDT: {
+    symbol: "BNBUSDT",
+    baseAsset: "BNB",
+    quoteAsset: "USDT",
+  },
+  VENBNB: {
+    symbol: "VENBNB",
+    baseAsset: "VEN",
+    quoteAsset: "BNB",
+  },
+  YOYOBNB: {
+    symbol: "YOYOBNB",
+    baseAsset: "YOYO",
+    quoteAsset: "BNB",
+  },
+  POWRBNB: {
+    symbol: "POWRBNB",
+    baseAsset: "POWR",
+    quoteAsset: "BNB",
+  },
+  VENBTC: {
+    symbol: "VENBTC",
+    baseAsset: "VEN",
+    quoteAsset: "BTC",
+  },
+  VENETH: {
+    symbol: "VENETH",
+    baseAsset: "VEN",
+    quoteAsset: "ETH",
+  },
+  KMDBTC: {
+    symbol: "KMDBTC",
+    baseAsset: "KMD",
+    quoteAsset: "BTC",
+  },
+  KMDETH: {
+    symbol: "KMDETH",
+    baseAsset: "KMD",
+    quoteAsset: "ETH",
+  },
+  NULSBNB: {
+    symbol: "NULSBNB",
+    baseAsset: "NULS",
+    quoteAsset: "BNB",
+  },
+  RCNBTC: {
+    symbol: "RCNBTC",
+    baseAsset: "RCN",
+    quoteAsset: "BTC",
+  },
+  RCNETH: {
+    symbol: "RCNETH",
+    baseAsset: "RCN",
+    quoteAsset: "ETH",
+  },
+  RCNBNB: {
+    symbol: "RCNBNB",
+    baseAsset: "RCN",
+    quoteAsset: "BNB",
+  },
+  NULSBTC: {
+    symbol: "NULSBTC",
+    baseAsset: "NULS",
+    quoteAsset: "BTC",
+  },
+  NULSETH: {
+    symbol: "NULSETH",
+    baseAsset: "NULS",
+    quoteAsset: "ETH",
+  },
+  RDNBTC: {
+    symbol: "RDNBTC",
+    baseAsset: "RDN",
+    quoteAsset: "BTC",
+  },
+  RDNETH: {
+    symbol: "RDNETH",
+    baseAsset: "RDN",
+    quoteAsset: "ETH",
+  },
+  RDNBNB: {
+    symbol: "RDNBNB",
+    baseAsset: "RDN",
+    quoteAsset: "BNB",
+  },
+  XMRBTC: {
+    symbol: "XMRBTC",
+    baseAsset: "XMR",
+    quoteAsset: "BTC",
+  },
+  XMRETH: {
+    symbol: "XMRETH",
+    baseAsset: "XMR",
+    quoteAsset: "ETH",
+  },
+  DLTBNB: {
+    symbol: "DLTBNB",
+    baseAsset: "DLT",
+    quoteAsset: "BNB",
+  },
+  WTCBNB: {
+    symbol: "WTCBNB",
+    baseAsset: "WTC",
+    quoteAsset: "BNB",
+  },
+  DLTBTC: {
+    symbol: "DLTBTC",
+    baseAsset: "DLT",
+    quoteAsset: "BTC",
+  },
+  DLTETH: {
+    symbol: "DLTETH",
+    baseAsset: "DLT",
+    quoteAsset: "ETH",
+  },
+  AMBBTC: {
+    symbol: "AMBBTC",
+    baseAsset: "AMB",
+    quoteAsset: "BTC",
+  },
+  AMBETH: {
+    symbol: "AMBETH",
+    baseAsset: "AMB",
+    quoteAsset: "ETH",
+  },
+  AMBBNB: {
+    symbol: "AMBBNB",
+    baseAsset: "AMB",
+    quoteAsset: "BNB",
+  },
+  BCCETH: {
+    symbol: "BCCETH",
+    baseAsset: "BCC",
+    quoteAsset: "ETH",
+  },
+  BCCUSDT: {
+    symbol: "BCCUSDT",
+    baseAsset: "BCC",
+    quoteAsset: "USDT",
+  },
+  BCCBNB: {
+    symbol: "BCCBNB",
+    baseAsset: "BCC",
+    quoteAsset: "BNB",
+  },
+  BATBTC: {
+    symbol: "BATBTC",
+    baseAsset: "BAT",
+    quoteAsset: "BTC",
+  },
+  BATETH: {
+    symbol: "BATETH",
+    baseAsset: "BAT",
+    quoteAsset: "ETH",
+  },
+  BATBNB: {
+    symbol: "BATBNB",
+    baseAsset: "BAT",
+    quoteAsset: "BNB",
+  },
+  BCPTBTC: {
+    symbol: "BCPTBTC",
+    baseAsset: "BCPT",
+    quoteAsset: "BTC",
+  },
+  BCPTETH: {
+    symbol: "BCPTETH",
+    baseAsset: "BCPT",
+    quoteAsset: "ETH",
+  },
+  BCPTBNB: {
+    symbol: "BCPTBNB",
+    baseAsset: "BCPT",
+    quoteAsset: "BNB",
+  },
+  ARNBTC: {
+    symbol: "ARNBTC",
+    baseAsset: "ARN",
+    quoteAsset: "BTC",
+  },
+  ARNETH: {
+    symbol: "ARNETH",
+    baseAsset: "ARN",
+    quoteAsset: "ETH",
+  },
+  GVTBTC: {
+    symbol: "GVTBTC",
+    baseAsset: "GVT",
+    quoteAsset: "BTC",
+  },
+  GVTETH: {
+    symbol: "GVTETH",
+    baseAsset: "GVT",
+    quoteAsset: "ETH",
+  },
+  CDTBTC: {
+    symbol: "CDTBTC",
+    baseAsset: "CDT",
+    quoteAsset: "BTC",
+  },
+  CDTETH: {
+    symbol: "CDTETH",
+    baseAsset: "CDT",
+    quoteAsset: "ETH",
+  },
+  GXSBTC: {
+    symbol: "GXSBTC",
+    baseAsset: "GXS",
+    quoteAsset: "BTC",
+  },
+  GXSETH: {
+    symbol: "GXSETH",
+    baseAsset: "GXS",
+    quoteAsset: "ETH",
+  },
+  NEOUSDT: {
+    symbol: "NEOUSDT",
+    baseAsset: "NEO",
+    quoteAsset: "USDT",
+  },
+  NEOBNB: {
+    symbol: "NEOBNB",
+    baseAsset: "NEO",
+    quoteAsset: "BNB",
+  },
+  POEBTC: {
+    symbol: "POEBTC",
+    baseAsset: "POE",
+    quoteAsset: "BTC",
+  },
+  POEETH: {
+    symbol: "POEETH",
+    baseAsset: "POE",
+    quoteAsset: "ETH",
+  },
+  QSPBTC: {
+    symbol: "QSPBTC",
+    baseAsset: "QSP",
+    quoteAsset: "BTC",
+  },
+  QSPETH: {
+    symbol: "QSPETH",
+    baseAsset: "QSP",
+    quoteAsset: "ETH",
+  },
+  QSPBNB: {
+    symbol: "QSPBNB",
+    baseAsset: "QSP",
+    quoteAsset: "BNB",
+  },
+  BTSBTC: {
+    symbol: "BTSBTC",
+    baseAsset: "BTS",
+    quoteAsset: "BTC",
+  },
+  BTSETH: {
+    symbol: "BTSETH",
+    baseAsset: "BTS",
+    quoteAsset: "ETH",
+  },
+  BTSBNB: {
+    symbol: "BTSBNB",
+    baseAsset: "BTS",
+    quoteAsset: "BNB",
+  },
+  XZCBTC: {
+    symbol: "XZCBTC",
+    baseAsset: "XZC",
+    quoteAsset: "BTC",
+  },
+  XZCETH: {
+    symbol: "XZCETH",
+    baseAsset: "XZC",
+    quoteAsset: "ETH",
+  },
+  XZCBNB: {
+    symbol: "XZCBNB",
+    baseAsset: "XZC",
+    quoteAsset: "BNB",
+  },
+  LSKBTC: {
+    symbol: "LSKBTC",
+    baseAsset: "LSK",
+    quoteAsset: "BTC",
+  },
+  LSKETH: {
+    symbol: "LSKETH",
+    baseAsset: "LSK",
+    quoteAsset: "ETH",
+  },
+  LSKBNB: {
+    symbol: "LSKBNB",
+    baseAsset: "LSK",
+    quoteAsset: "BNB",
+  },
+  TNTBTC: {
+    symbol: "TNTBTC",
+    baseAsset: "TNT",
+    quoteAsset: "BTC",
+  },
+  TNTETH: {
+    symbol: "TNTETH",
+    baseAsset: "TNT",
+    quoteAsset: "ETH",
+  },
+  FUELBTC: {
+    symbol: "FUELBTC",
+    baseAsset: "FUEL",
+    quoteAsset: "BTC",
+  },
+  FUELETH: {
+    symbol: "FUELETH",
+    baseAsset: "FUEL",
+    quoteAsset: "ETH",
+  },
+  MANABTC: {
+    symbol: "MANABTC",
+    baseAsset: "MANA",
+    quoteAsset: "BTC",
+  },
+  MANAETH: {
+    symbol: "MANAETH",
+    baseAsset: "MANA",
+    quoteAsset: "ETH",
+  },
+  BCDBTC: {
+    symbol: "BCDBTC",
+    baseAsset: "BCD",
+    quoteAsset: "BTC",
+  },
+  BCDETH: {
+    symbol: "BCDETH",
+    baseAsset: "BCD",
+    quoteAsset: "ETH",
+  },
+  DGDBTC: {
+    symbol: "DGDBTC",
+    baseAsset: "DGD",
+    quoteAsset: "BTC",
+  },
+  DGDETH: {
+    symbol: "DGDETH",
+    baseAsset: "DGD",
+    quoteAsset: "ETH",
+  },
+  IOTABNB: {
+    symbol: "IOTABNB",
+    baseAsset: "IOTA",
+    quoteAsset: "BNB",
+  },
+  ADXBTC: {
+    symbol: "ADXBTC",
+    baseAsset: "ADX",
+    quoteAsset: "BTC",
+  },
+  ADXETH: {
+    symbol: "ADXETH",
+    baseAsset: "ADX",
+    quoteAsset: "ETH",
+  },
+  ADXBNB: {
+    symbol: "ADXBNB",
+    baseAsset: "ADX",
+    quoteAsset: "BNB",
+  },
+  ADABTC: {
+    symbol: "ADABTC",
+    baseAsset: "ADA",
+    quoteAsset: "BTC",
+  },
+  ADAETH: {
+    symbol: "ADAETH",
+    baseAsset: "ADA",
+    quoteAsset: "ETH",
+  },
+  PPTBTC: {
+    symbol: "PPTBTC",
+    baseAsset: "PPT",
+    quoteAsset: "BTC",
+  },
+  PPTETH: {
+    symbol: "PPTETH",
+    baseAsset: "PPT",
+    quoteAsset: "ETH",
+  },
+  CMTBTC: {
+    symbol: "CMTBTC",
+    baseAsset: "CMT",
+    quoteAsset: "BTC",
+  },
+  CMTETH: {
+    symbol: "CMTETH",
+    baseAsset: "CMT",
+    quoteAsset: "ETH",
+  },
+  CMTBNB: {
+    symbol: "CMTBNB",
+    baseAsset: "CMT",
+    quoteAsset: "BNB",
+  },
+  XLMBTC: {
+    symbol: "XLMBTC",
+    baseAsset: "XLM",
+    quoteAsset: "BTC",
+  },
+  XLMETH: {
+    symbol: "XLMETH",
+    baseAsset: "XLM",
+    quoteAsset: "ETH",
+  },
+  XLMBNB: {
+    symbol: "XLMBNB",
+    baseAsset: "XLM",
+    quoteAsset: "BNB",
+  },
+  CNDBTC: {
+    symbol: "CNDBTC",
+    baseAsset: "CND",
+    quoteAsset: "BTC",
+  },
+  CNDETH: {
+    symbol: "CNDETH",
+    baseAsset: "CND",
+    quoteAsset: "ETH",
+  },
+  CNDBNB: {
+    symbol: "CNDBNB",
+    baseAsset: "CND",
+    quoteAsset: "BNB",
+  },
+  LENDBTC: {
+    symbol: "LENDBTC",
+    baseAsset: "LEND",
+    quoteAsset: "BTC",
+  },
+  LENDETH: {
+    symbol: "LENDETH",
+    baseAsset: "LEND",
+    quoteAsset: "ETH",
+  },
+  WABIBTC: {
+    symbol: "WABIBTC",
+    baseAsset: "WABI",
+    quoteAsset: "BTC",
+  },
+  WABIETH: {
+    symbol: "WABIETH",
+    baseAsset: "WABI",
+    quoteAsset: "ETH",
+  },
+  WABIBNB: {
+    symbol: "WABIBNB",
+    baseAsset: "WABI",
+    quoteAsset: "BNB",
+  },
+  LTCETH: {
+    symbol: "LTCETH",
+    baseAsset: "LTC",
+    quoteAsset: "ETH",
+  },
+  LTCUSDT: {
+    symbol: "LTCUSDT",
+    baseAsset: "LTC",
+    quoteAsset: "USDT",
+  },
+  LTCBNB: {
+    symbol: "LTCBNB",
+    baseAsset: "LTC",
+    quoteAsset: "BNB",
+  },
+  TNBBTC: {
+    symbol: "TNBBTC",
+    baseAsset: "TNB",
+    quoteAsset: "BTC",
+  },
+  TNBETH: {
+    symbol: "TNBETH",
+    baseAsset: "TNB",
+    quoteAsset: "ETH",
+  },
+  WAVESBTC: {
+    symbol: "WAVESBTC",
+    baseAsset: "WAVES",
+    quoteAsset: "BTC",
+  },
+  WAVESETH: {
+    symbol: "WAVESETH",
+    baseAsset: "WAVES",
+    quoteAsset: "ETH",
+  },
+  WAVESBNB: {
+    symbol: "WAVESBNB",
+    baseAsset: "WAVES",
+    quoteAsset: "BNB",
+  },
+  GTOBTC: {
+    symbol: "GTOBTC",
+    baseAsset: "GTO",
+    quoteAsset: "BTC",
+  },
+  GTOETH: {
+    symbol: "GTOETH",
+    baseAsset: "GTO",
+    quoteAsset: "ETH",
+  },
+  GTOBNB: {
+    symbol: "GTOBNB",
+    baseAsset: "GTO",
+    quoteAsset: "BNB",
+  },
+  ICXBTC: {
+    symbol: "ICXBTC",
+    baseAsset: "ICX",
+    quoteAsset: "BTC",
+  },
+  ICXETH: {
+    symbol: "ICXETH",
+    baseAsset: "ICX",
+    quoteAsset: "ETH",
+  },
+  ICXBNB: {
+    symbol: "ICXBNB",
+    baseAsset: "ICX",
+    quoteAsset: "BNB",
+  },
+  OSTBTC: {
+    symbol: "OSTBTC",
+    baseAsset: "OST",
+    quoteAsset: "BTC",
+  },
+  OSTETH: {
+    symbol: "OSTETH",
+    baseAsset: "OST",
+    quoteAsset: "ETH",
+  },
+  OSTBNB: {
+    symbol: "OSTBNB",
+    baseAsset: "OST",
+    quoteAsset: "BNB",
+  },
+  ELFBTC: {
+    symbol: "ELFBTC",
+    baseAsset: "ELF",
+    quoteAsset: "BTC",
+  },
+  ELFETH: {
+    symbol: "ELFETH",
+    baseAsset: "ELF",
+    quoteAsset: "ETH",
+  },
+  AIONBTC: {
+    symbol: "AIONBTC",
+    baseAsset: "AION",
+    quoteAsset: "BTC",
+  },
+  AIONETH: {
+    symbol: "AIONETH",
+    baseAsset: "AION",
+    quoteAsset: "ETH",
+  },
+  AIONBNB: {
+    symbol: "AIONBNB",
+    baseAsset: "AION",
+    quoteAsset: "BNB",
+  },
+  NEBLBTC: {
+    symbol: "NEBLBTC",
+    baseAsset: "NEBL",
+    quoteAsset: "BTC",
+  },
+  NEBLETH: {
+    symbol: "NEBLETH",
+    baseAsset: "NEBL",
+    quoteAsset: "ETH",
+  },
+  NEBLBNB: {
+    symbol: "NEBLBNB",
+    baseAsset: "NEBL",
+    quoteAsset: "BNB",
+  },
+  BRDBTC: {
+    symbol: "BRDBTC",
+    baseAsset: "BRD",
+    quoteAsset: "BTC",
+  },
+  BRDETH: {
+    symbol: "BRDETH",
+    baseAsset: "BRD",
+    quoteAsset: "ETH",
+  },
+  BRDBNB: {
+    symbol: "BRDBNB",
+    baseAsset: "BRD",
+    quoteAsset: "BNB",
+  },
+  MCOBNB: {
+    symbol: "MCOBNB",
+    baseAsset: "MCO",
+    quoteAsset: "BNB",
+  },
+  EDOBTC: {
+    symbol: "EDOBTC",
+    baseAsset: "EDO",
+    quoteAsset: "BTC",
+  },
+  EDOETH: {
+    symbol: "EDOETH",
+    baseAsset: "EDO",
+    quoteAsset: "ETH",
+  },
+  WINGSBTC: {
+    symbol: "WINGSBTC",
+    baseAsset: "WINGS",
+    quoteAsset: "BTC",
+  },
+  WINGSETH: {
+    symbol: "WINGSETH",
+    baseAsset: "WINGS",
+    quoteAsset: "ETH",
+  },
+  NAVBTC: {
+    symbol: "NAVBTC",
+    baseAsset: "NAV",
+    quoteAsset: "BTC",
+  },
+  NAVETH: {
+    symbol: "NAVETH",
+    baseAsset: "NAV",
+    quoteAsset: "ETH",
+  },
+  NAVBNB: {
+    symbol: "NAVBNB",
+    baseAsset: "NAV",
+    quoteAsset: "BNB",
+  },
+  LUNBTC: {
+    symbol: "LUNBTC",
+    baseAsset: "LUN",
+    quoteAsset: "BTC",
+  },
+  LUNETH: {
+    symbol: "LUNETH",
+    baseAsset: "LUN",
+    quoteAsset: "ETH",
+  },
+  TRIGBTC: {
+    symbol: "TRIGBTC",
+    baseAsset: "TRIG",
+    quoteAsset: "BTC",
+  },
+  TRIGETH: {
+    symbol: "TRIGETH",
+    baseAsset: "TRIG",
+    quoteAsset: "ETH",
+  },
+  TRIGBNB: {
+    symbol: "TRIGBNB",
+    baseAsset: "TRIG",
+    quoteAsset: "BNB",
+  },
+  APPCBTC: {
+    symbol: "APPCBTC",
+    baseAsset: "APPC",
+    quoteAsset: "BTC",
+  },
+  APPCETH: {
+    symbol: "APPCETH",
+    baseAsset: "APPC",
+    quoteAsset: "ETH",
+  },
+  APPCBNB: {
+    symbol: "APPCBNB",
+    baseAsset: "APPC",
+    quoteAsset: "BNB",
+  },
+  VIBEBTC: {
+    symbol: "VIBEBTC",
+    baseAsset: "VIBE",
+    quoteAsset: "BTC",
+  },
+  VIBEETH: {
+    symbol: "VIBEETH",
+    baseAsset: "VIBE",
+    quoteAsset: "ETH",
+  },
+  RLCBTC: {
+    symbol: "RLCBTC",
+    baseAsset: "RLC",
+    quoteAsset: "BTC",
+  },
+  RLCETH: {
+    symbol: "RLCETH",
+    baseAsset: "RLC",
+    quoteAsset: "ETH",
+  },
+  RLCBNB: {
+    symbol: "RLCBNB",
+    baseAsset: "RLC",
+    quoteAsset: "BNB",
+  },
+  INSBTC: {
+    symbol: "INSBTC",
+    baseAsset: "INS",
+    quoteAsset: "BTC",
+  },
+  INSETH: {
+    symbol: "INSETH",
+    baseAsset: "INS",
+    quoteAsset: "ETH",
+  },
+  PIVXBTC: {
+    symbol: "PIVXBTC",
+    baseAsset: "PIVX",
+    quoteAsset: "BTC",
+  },
+  PIVXETH: {
+    symbol: "PIVXETH",
+    baseAsset: "PIVX",
+    quoteAsset: "ETH",
+  },
+  PIVXBNB: {
+    symbol: "PIVXBNB",
+    baseAsset: "PIVX",
+    quoteAsset: "BNB",
+  },
+  IOSTBTC: {
+    symbol: "IOSTBTC",
+    baseAsset: "IOST",
+    quoteAsset: "BTC",
+  },
+  IOSTETH: {
+    symbol: "IOSTETH",
+    baseAsset: "IOST",
+    quoteAsset: "ETH",
+  },
+  CHATBTC: {
+    symbol: "CHATBTC",
+    baseAsset: "CHAT",
+    quoteAsset: "BTC",
+  },
+  CHATETH: {
+    symbol: "CHATETH",
+    baseAsset: "CHAT",
+    quoteAsset: "ETH",
+  },
+  STEEMBTC: {
+    symbol: "STEEMBTC",
+    baseAsset: "STEEM",
+    quoteAsset: "BTC",
+  },
+  STEEMETH: {
+    symbol: "STEEMETH",
+    baseAsset: "STEEM",
+    quoteAsset: "ETH",
+  },
+  STEEMBNB: {
+    symbol: "STEEMBNB",
+    baseAsset: "STEEM",
+    quoteAsset: "BNB",
+  },
+  NANOBTC: {
+    symbol: "NANOBTC",
+    baseAsset: "NANO",
+    quoteAsset: "BTC",
+  },
+  NANOETH: {
+    symbol: "NANOETH",
+    baseAsset: "NANO",
+    quoteAsset: "ETH",
+  },
+  NANOBNB: {
+    symbol: "NANOBNB",
+    baseAsset: "NANO",
+    quoteAsset: "BNB",
+  },
+  VIABTC: {
+    symbol: "VIABTC",
+    baseAsset: "VIA",
+    quoteAsset: "BTC",
+  },
+  VIAETH: {
+    symbol: "VIAETH",
+    baseAsset: "VIA",
+    quoteAsset: "ETH",
+  },
+  VIABNB: {
+    symbol: "VIABNB",
+    baseAsset: "VIA",
+    quoteAsset: "BNB",
+  },
+  BLZBTC: {
+    symbol: "BLZBTC",
+    baseAsset: "BLZ",
+    quoteAsset: "BTC",
+  },
+  BLZETH: {
+    symbol: "BLZETH",
+    baseAsset: "BLZ",
+    quoteAsset: "ETH",
+  },
+  BLZBNB: {
+    symbol: "BLZBNB",
+    baseAsset: "BLZ",
+    quoteAsset: "BNB",
+  },
+  AEBTC: {
+    symbol: "AEBTC",
+    baseAsset: "AE",
+    quoteAsset: "BTC",
+  },
+  AEETH: {
+    symbol: "AEETH",
+    baseAsset: "AE",
+    quoteAsset: "ETH",
+  },
+  AEBNB: {
+    symbol: "AEBNB",
+    baseAsset: "AE",
+    quoteAsset: "BNB",
+  },
+  RPXBTC: {
+    symbol: "RPXBTC",
+    baseAsset: "RPX",
+    quoteAsset: "BTC",
+  },
+  RPXETH: {
+    symbol: "RPXETH",
+    baseAsset: "RPX",
+    quoteAsset: "ETH",
+  },
+  RPXBNB: {
+    symbol: "RPXBNB",
+    baseAsset: "RPX",
+    quoteAsset: "BNB",
+  },
+  NCASHBTC: {
+    symbol: "NCASHBTC",
+    baseAsset: "NCASH",
+    quoteAsset: "BTC",
+  },
+  NCASHETH: {
+    symbol: "NCASHETH",
+    baseAsset: "NCASH",
+    quoteAsset: "ETH",
+  },
+  NCASHBNB: {
+    symbol: "NCASHBNB",
+    baseAsset: "NCASH",
+    quoteAsset: "BNB",
+  },
+  POABTC: {
+    symbol: "POABTC",
+    baseAsset: "POA",
+    quoteAsset: "BTC",
+  },
+  POAETH: {
+    symbol: "POAETH",
+    baseAsset: "POA",
+    quoteAsset: "ETH",
+  },
+  POABNB: {
+    symbol: "POABNB",
+    baseAsset: "POA",
+    quoteAsset: "BNB",
+  },
+  ZILBTC: {
+    symbol: "ZILBTC",
+    baseAsset: "ZIL",
+    quoteAsset: "BTC",
+  },
+  ZILETH: {
+    symbol: "ZILETH",
+    baseAsset: "ZIL",
+    quoteAsset: "ETH",
+  },
+  ZILBNB: {
+    symbol: "ZILBNB",
+    baseAsset: "ZIL",
+    quoteAsset: "BNB",
+  },
+  ONTBTC: {
+    symbol: "ONTBTC",
+    baseAsset: "ONT",
+    quoteAsset: "BTC",
+  },
+  ONTETH: {
+    symbol: "ONTETH",
+    baseAsset: "ONT",
+    quoteAsset: "ETH",
+  },
+  ONTBNB: {
+    symbol: "ONTBNB",
+    baseAsset: "ONT",
+    quoteAsset: "BNB",
+  },
+  STORMBTC: {
+    symbol: "STORMBTC",
+    baseAsset: "STORM",
+    quoteAsset: "BTC",
+  },
+  STORMETH: {
+    symbol: "STORMETH",
+    baseAsset: "STORM",
+    quoteAsset: "ETH",
+  },
+  STORMBNB: {
+    symbol: "STORMBNB",
+    baseAsset: "STORM",
+    quoteAsset: "BNB",
+  },
+  QTUMBNB: {
+    symbol: "QTUMBNB",
+    baseAsset: "QTUM",
+    quoteAsset: "BNB",
+  },
+  QTUMUSDT: {
+    symbol: "QTUMUSDT",
+    baseAsset: "QTUM",
+    quoteAsset: "USDT",
+  },
+  XEMBTC: {
+    symbol: "XEMBTC",
+    baseAsset: "XEM",
+    quoteAsset: "BTC",
+  },
+  XEMETH: {
+    symbol: "XEMETH",
+    baseAsset: "XEM",
+    quoteAsset: "ETH",
+  },
+  XEMBNB: {
+    symbol: "XEMBNB",
+    baseAsset: "XEM",
+    quoteAsset: "BNB",
+  },
+  WANBTC: {
+    symbol: "WANBTC",
+    baseAsset: "WAN",
+    quoteAsset: "BTC",
+  },
+  WANETH: {
+    symbol: "WANETH",
+    baseAsset: "WAN",
+    quoteAsset: "ETH",
+  },
+  WANBNB: {
+    symbol: "WANBNB",
+    baseAsset: "WAN",
+    quoteAsset: "BNB",
+  },
+  WPRBTC: {
+    symbol: "WPRBTC",
+    baseAsset: "WPR",
+    quoteAsset: "BTC",
+  },
+  WPRETH: {
+    symbol: "WPRETH",
+    baseAsset: "WPR",
+    quoteAsset: "ETH",
+  },
+  QLCBTC: {
+    symbol: "QLCBTC",
+    baseAsset: "QLC",
+    quoteAsset: "BTC",
+  },
+  QLCETH: {
+    symbol: "QLCETH",
+    baseAsset: "QLC",
+    quoteAsset: "ETH",
+  },
+  SYSBTC: {
+    symbol: "SYSBTC",
+    baseAsset: "SYS",
+    quoteAsset: "BTC",
+  },
+  SYSETH: {
+    symbol: "SYSETH",
+    baseAsset: "SYS",
+    quoteAsset: "ETH",
+  },
+  SYSBNB: {
+    symbol: "SYSBNB",
+    baseAsset: "SYS",
+    quoteAsset: "BNB",
+  },
+  QLCBNB: {
+    symbol: "QLCBNB",
+    baseAsset: "QLC",
+    quoteAsset: "BNB",
+  },
+  GRSBTC: {
+    symbol: "GRSBTC",
+    baseAsset: "GRS",
+    quoteAsset: "BTC",
+  },
+  GRSETH: {
+    symbol: "GRSETH",
+    baseAsset: "GRS",
+    quoteAsset: "ETH",
+  },
+  ADAUSDT: {
+    symbol: "ADAUSDT",
+    baseAsset: "ADA",
+    quoteAsset: "USDT",
+  },
+  ADABNB: {
+    symbol: "ADABNB",
+    baseAsset: "ADA",
+    quoteAsset: "BNB",
+  },
+  CLOAKBTC: {
+    symbol: "CLOAKBTC",
+    baseAsset: "CLOAK",
+    quoteAsset: "BTC",
+  },
+  CLOAKETH: {
+    symbol: "CLOAKETH",
+    baseAsset: "CLOAK",
+    quoteAsset: "ETH",
+  },
+  GNTBTC: {
+    symbol: "GNTBTC",
+    baseAsset: "GNT",
+    quoteAsset: "BTC",
+  },
+  GNTETH: {
+    symbol: "GNTETH",
+    baseAsset: "GNT",
+    quoteAsset: "ETH",
+  },
+  GNTBNB: {
+    symbol: "GNTBNB",
+    baseAsset: "GNT",
+    quoteAsset: "BNB",
+  },
+  LOOMBTC: {
+    symbol: "LOOMBTC",
+    baseAsset: "LOOM",
+    quoteAsset: "BTC",
+  },
+  LOOMETH: {
+    symbol: "LOOMETH",
+    baseAsset: "LOOM",
+    quoteAsset: "ETH",
+  },
+  LOOMBNB: {
+    symbol: "LOOMBNB",
+    baseAsset: "LOOM",
+    quoteAsset: "BNB",
+  },
+  XRPUSDT: {
+    symbol: "XRPUSDT",
+    baseAsset: "XRP",
+    quoteAsset: "USDT",
+  },
+  BCNBTC: {
+    symbol: "BCNBTC",
+    baseAsset: "BCN",
+    quoteAsset: "BTC",
+  },
+  BCNETH: {
+    symbol: "BCNETH",
+    baseAsset: "BCN",
+    quoteAsset: "ETH",
+  },
+  BCNBNB: {
+    symbol: "BCNBNB",
+    baseAsset: "BCN",
+    quoteAsset: "BNB",
+  },
+  REPBTC: {
+    symbol: "REPBTC",
+    baseAsset: "REP",
+    quoteAsset: "BTC",
+  },
+  REPETH: {
+    symbol: "REPETH",
+    baseAsset: "REP",
+    quoteAsset: "ETH",
+  },
+  REPBNB: {
+    symbol: "REPBNB",
+    baseAsset: "REP",
+    quoteAsset: "BNB",
+  },
+  BTCTUSD: {
+    symbol: "BTCTUSD",
+    baseAsset: "BTC",
+    quoteAsset: "TUSD",
+  },
+  TUSDBTC: {
+    symbol: "TUSDBTC",
+    baseAsset: "TUSD",
+    quoteAsset: "BTC",
+  },
+  ETHTUSD: {
+    symbol: "ETHTUSD",
+    baseAsset: "ETH",
+    quoteAsset: "TUSD",
+  },
+  TUSDETH: {
+    symbol: "TUSDETH",
+    baseAsset: "TUSD",
+    quoteAsset: "ETH",
+  },
+  TUSDBNB: {
+    symbol: "TUSDBNB",
+    baseAsset: "TUSD",
+    quoteAsset: "BNB",
+  },
+  ZENBTC: {
+    symbol: "ZENBTC",
+    baseAsset: "ZEN",
+    quoteAsset: "BTC",
+  },
+  ZENETH: {
+    symbol: "ZENETH",
+    baseAsset: "ZEN",
+    quoteAsset: "ETH",
+  },
+  ZENBNB: {
+    symbol: "ZENBNB",
+    baseAsset: "ZEN",
+    quoteAsset: "BNB",
+  },
+  SKYBTC: {
+    symbol: "SKYBTC",
+    baseAsset: "SKY",
+    quoteAsset: "BTC",
+  },
+  SKYETH: {
+    symbol: "SKYETH",
+    baseAsset: "SKY",
+    quoteAsset: "ETH",
+  },
+  SKYBNB: {
+    symbol: "SKYBNB",
+    baseAsset: "SKY",
+    quoteAsset: "BNB",
+  },
+  EOSUSDT: {
+    symbol: "EOSUSDT",
+    baseAsset: "EOS",
+    quoteAsset: "USDT",
+  },
+  EOSBNB: {
+    symbol: "EOSBNB",
+    baseAsset: "EOS",
+    quoteAsset: "BNB",
+  },
+  CVCBTC: {
+    symbol: "CVCBTC",
+    baseAsset: "CVC",
+    quoteAsset: "BTC",
+  },
+  CVCETH: {
+    symbol: "CVCETH",
+    baseAsset: "CVC",
+    quoteAsset: "ETH",
+  },
+  CVCBNB: {
+    symbol: "CVCBNB",
+    baseAsset: "CVC",
+    quoteAsset: "BNB",
+  },
+  THETABTC: {
+    symbol: "THETABTC",
+    baseAsset: "THETA",
+    quoteAsset: "BTC",
+  },
+  THETAETH: {
+    symbol: "THETAETH",
+    baseAsset: "THETA",
+    quoteAsset: "ETH",
+  },
+  THETABNB: {
+    symbol: "THETABNB",
+    baseAsset: "THETA",
+    quoteAsset: "BNB",
+  },
+  XRPBNB: {
+    symbol: "XRPBNB",
+    baseAsset: "XRP",
+    quoteAsset: "BNB",
+  },
+  TUSDUSDT: {
+    symbol: "TUSDUSDT",
+    baseAsset: "TUSD",
+    quoteAsset: "USDT",
+  },
+  IOTAUSDT: {
+    symbol: "IOTAUSDT",
+    baseAsset: "IOTA",
+    quoteAsset: "USDT",
+  },
+  XLMUSDT: {
+    symbol: "XLMUSDT",
+    baseAsset: "XLM",
+    quoteAsset: "USDT",
+  },
+  IOTXBTC: {
+    symbol: "IOTXBTC",
+    baseAsset: "IOTX",
+    quoteAsset: "BTC",
+  },
+  IOTXETH: {
+    symbol: "IOTXETH",
+    baseAsset: "IOTX",
+    quoteAsset: "ETH",
+  },
+  QKCBTC: {
+    symbol: "QKCBTC",
+    baseAsset: "QKC",
+    quoteAsset: "BTC",
+  },
+  QKCETH: {
+    symbol: "QKCETH",
+    baseAsset: "QKC",
+    quoteAsset: "ETH",
+  },
+  AGIBTC: {
+    symbol: "AGIBTC",
+    baseAsset: "AGI",
+    quoteAsset: "BTC",
+  },
+  AGIETH: {
+    symbol: "AGIETH",
+    baseAsset: "AGI",
+    quoteAsset: "ETH",
+  },
+  AGIBNB: {
+    symbol: "AGIBNB",
+    baseAsset: "AGI",
+    quoteAsset: "BNB",
+  },
+  NXSBTC: {
+    symbol: "NXSBTC",
+    baseAsset: "NXS",
+    quoteAsset: "BTC",
+  },
+  NXSETH: {
+    symbol: "NXSETH",
+    baseAsset: "NXS",
+    quoteAsset: "ETH",
+  },
+  NXSBNB: {
+    symbol: "NXSBNB",
+    baseAsset: "NXS",
+    quoteAsset: "BNB",
+  },
+  ENJBNB: {
+    symbol: "ENJBNB",
+    baseAsset: "ENJ",
+    quoteAsset: "BNB",
+  },
+  DATABTC: {
+    symbol: "DATABTC",
+    baseAsset: "DATA",
+    quoteAsset: "BTC",
+  },
+  DATAETH: {
+    symbol: "DATAETH",
+    baseAsset: "DATA",
+    quoteAsset: "ETH",
+  },
+  ONTUSDT: {
+    symbol: "ONTUSDT",
+    baseAsset: "ONT",
+    quoteAsset: "USDT",
+  },
+  TRXBNB: {
+    symbol: "TRXBNB",
+    baseAsset: "TRX",
+    quoteAsset: "BNB",
+  },
+  TRXUSDT: {
+    symbol: "TRXUSDT",
+    baseAsset: "TRX",
+    quoteAsset: "USDT",
+  },
+  ETCUSDT: {
+    symbol: "ETCUSDT",
+    baseAsset: "ETC",
+    quoteAsset: "USDT",
+  },
+  ETCBNB: {
+    symbol: "ETCBNB",
+    baseAsset: "ETC",
+    quoteAsset: "BNB",
+  },
+  ICXUSDT: {
+    symbol: "ICXUSDT",
+    baseAsset: "ICX",
+    quoteAsset: "USDT",
+  },
+  SCBTC: {
+    symbol: "SCBTC",
+    baseAsset: "SC",
+    quoteAsset: "BTC",
+  },
+  SCETH: {
+    symbol: "SCETH",
+    baseAsset: "SC",
+    quoteAsset: "ETH",
+  },
+  SCBNB: {
+    symbol: "SCBNB",
+    baseAsset: "SC",
+    quoteAsset: "BNB",
+  },
+  NPXSBTC: {
+    symbol: "NPXSBTC",
+    baseAsset: "NPXS",
+    quoteAsset: "BTC",
+  },
+  NPXSETH: {
+    symbol: "NPXSETH",
+    baseAsset: "NPXS",
+    quoteAsset: "ETH",
+  },
+  VENUSDT: {
+    symbol: "VENUSDT",
+    baseAsset: "VEN",
+    quoteAsset: "USDT",
+  },
+  KEYBTC: {
+    symbol: "KEYBTC",
+    baseAsset: "KEY",
+    quoteAsset: "BTC",
+  },
+  KEYETH: {
+    symbol: "KEYETH",
+    baseAsset: "KEY",
+    quoteAsset: "ETH",
+  },
+  NASBTC: {
+    symbol: "NASBTC",
+    baseAsset: "NAS",
+    quoteAsset: "BTC",
+  },
+  NASETH: {
+    symbol: "NASETH",
+    baseAsset: "NAS",
+    quoteAsset: "ETH",
+  },
+  NASBNB: {
+    symbol: "NASBNB",
+    baseAsset: "NAS",
+    quoteAsset: "BNB",
+  },
+  MFTBTC: {
+    symbol: "MFTBTC",
+    baseAsset: "MFT",
+    quoteAsset: "BTC",
+  },
+  MFTETH: {
+    symbol: "MFTETH",
+    baseAsset: "MFT",
+    quoteAsset: "ETH",
+  },
+  MFTBNB: {
+    symbol: "MFTBNB",
+    baseAsset: "MFT",
+    quoteAsset: "BNB",
+  },
+  DENTBTC: {
+    symbol: "DENTBTC",
+    baseAsset: "DENT",
+    quoteAsset: "BTC",
+  },
+  DENTETH: {
+    symbol: "DENTETH",
+    baseAsset: "DENT",
+    quoteAsset: "ETH",
+  },
+  ARDRBTC: {
+    symbol: "ARDRBTC",
+    baseAsset: "ARDR",
+    quoteAsset: "BTC",
+  },
+  ARDRETH: {
+    symbol: "ARDRETH",
+    baseAsset: "ARDR",
+    quoteAsset: "ETH",
+  },
+  ARDRBNB: {
+    symbol: "ARDRBNB",
+    baseAsset: "ARDR",
+    quoteAsset: "BNB",
+  },
+  NULSUSDT: {
+    symbol: "NULSUSDT",
+    baseAsset: "NULS",
+    quoteAsset: "USDT",
+  },
+  HOTBTC: {
+    symbol: "HOTBTC",
+    baseAsset: "HOT",
+    quoteAsset: "BTC",
+  },
+  HOTETH: {
+    symbol: "HOTETH",
+    baseAsset: "HOT",
+    quoteAsset: "ETH",
+  },
+  VETBTC: {
+    symbol: "VETBTC",
+    baseAsset: "VET",
+    quoteAsset: "BTC",
+  },
+  VETETH: {
+    symbol: "VETETH",
+    baseAsset: "VET",
+    quoteAsset: "ETH",
+  },
+  VETUSDT: {
+    symbol: "VETUSDT",
+    baseAsset: "VET",
+    quoteAsset: "USDT",
+  },
+  VETBNB: {
+    symbol: "VETBNB",
+    baseAsset: "VET",
+    quoteAsset: "BNB",
+  },
+  DOCKBTC: {
+    symbol: "DOCKBTC",
+    baseAsset: "DOCK",
+    quoteAsset: "BTC",
+  },
+  DOCKETH: {
+    symbol: "DOCKETH",
+    baseAsset: "DOCK",
+    quoteAsset: "ETH",
+  },
+  POLYBTC: {
+    symbol: "POLYBTC",
+    baseAsset: "POLY",
+    quoteAsset: "BTC",
+  },
+  POLYBNB: {
+    symbol: "POLYBNB",
+    baseAsset: "POLY",
+    quoteAsset: "BNB",
+  },
+  PHXBTC: {
+    symbol: "PHXBTC",
+    baseAsset: "PHX",
+    quoteAsset: "BTC",
+  },
+  PHXETH: {
+    symbol: "PHXETH",
+    baseAsset: "PHX",
+    quoteAsset: "ETH",
+  },
+  PHXBNB: {
+    symbol: "PHXBNB",
+    baseAsset: "PHX",
+    quoteAsset: "BNB",
+  },
+  HCBTC: {
+    symbol: "HCBTC",
+    baseAsset: "HC",
+    quoteAsset: "BTC",
+  },
+  HCETH: {
+    symbol: "HCETH",
+    baseAsset: "HC",
+    quoteAsset: "ETH",
+  },
+  GOBTC: {
+    symbol: "GOBTC",
+    baseAsset: "GO",
+    quoteAsset: "BTC",
+  },
+  GOBNB: {
+    symbol: "GOBNB",
+    baseAsset: "GO",
+    quoteAsset: "BNB",
+  },
+  PAXBTC: {
+    symbol: "PAXBTC",
+    baseAsset: "PAX",
+    quoteAsset: "BTC",
+  },
+  PAXBNB: {
+    symbol: "PAXBNB",
+    baseAsset: "PAX",
+    quoteAsset: "BNB",
+  },
+  PAXUSDT: {
+    symbol: "PAXUSDT",
+    baseAsset: "PAX",
+    quoteAsset: "USDT",
+  },
+  PAXETH: {
+    symbol: "PAXETH",
+    baseAsset: "PAX",
+    quoteAsset: "ETH",
+  },
+  RVNBTC: {
+    symbol: "RVNBTC",
+    baseAsset: "RVN",
+    quoteAsset: "BTC",
+  },
+  RVNBNB: {
+    symbol: "RVNBNB",
+    baseAsset: "RVN",
+    quoteAsset: "BNB",
+  },
+  DCRBTC: {
+    symbol: "DCRBTC",
+    baseAsset: "DCR",
+    quoteAsset: "BTC",
+  },
+  DCRBNB: {
+    symbol: "DCRBNB",
+    baseAsset: "DCR",
+    quoteAsset: "BNB",
+  },
+  USDCBNB: {
+    symbol: "USDCBNB",
+    baseAsset: "USDC",
+    quoteAsset: "BNB",
+  },
+  MITHBTC: {
+    symbol: "MITHBTC",
+    baseAsset: "MITH",
+    quoteAsset: "BTC",
+  },
+  MITHBNB: {
+    symbol: "MITHBNB",
+    baseAsset: "MITH",
+    quoteAsset: "BNB",
+  },
+  BCHABCBTC: {
+    symbol: "BCHABCBTC",
+    baseAsset: "BCHABC",
+    quoteAsset: "BTC",
+  },
+  BCHSVBTC: {
+    symbol: "BCHSVBTC",
+    baseAsset: "BCHSV",
+    quoteAsset: "BTC",
+  },
+  BCHABCUSDT: {
+    symbol: "BCHABCUSDT",
+    baseAsset: "BCHABC",
+    quoteAsset: "USDT",
+  },
+  BCHSVUSDT: {
+    symbol: "BCHSVUSDT",
+    baseAsset: "BCHSV",
+    quoteAsset: "USDT",
+  },
+  BNBPAX: {
+    symbol: "BNBPAX",
+    baseAsset: "BNB",
+    quoteAsset: "PAX",
+  },
+  BTCPAX: {
+    symbol: "BTCPAX",
+    baseAsset: "BTC",
+    quoteAsset: "PAX",
+  },
+  ETHPAX: {
+    symbol: "ETHPAX",
+    baseAsset: "ETH",
+    quoteAsset: "PAX",
+  },
+  XRPPAX: {
+    symbol: "XRPPAX",
+    baseAsset: "XRP",
+    quoteAsset: "PAX",
+  },
+  EOSPAX: {
+    symbol: "EOSPAX",
+    baseAsset: "EOS",
+    quoteAsset: "PAX",
+  },
+  XLMPAX: {
+    symbol: "XLMPAX",
+    baseAsset: "XLM",
+    quoteAsset: "PAX",
+  },
+  RENBTC: {
+    symbol: "RENBTC",
+    baseAsset: "REN",
+    quoteAsset: "BTC",
+  },
+  RENBNB: {
+    symbol: "RENBNB",
+    baseAsset: "REN",
+    quoteAsset: "BNB",
+  },
+  BNBTUSD: {
+    symbol: "BNBTUSD",
+    baseAsset: "BNB",
+    quoteAsset: "TUSD",
+  },
+  XRPTUSD: {
+    symbol: "XRPTUSD",
+    baseAsset: "XRP",
+    quoteAsset: "TUSD",
+  },
+  EOSTUSD: {
+    symbol: "EOSTUSD",
+    baseAsset: "EOS",
+    quoteAsset: "TUSD",
+  },
+  XLMTUSD: {
+    symbol: "XLMTUSD",
+    baseAsset: "XLM",
+    quoteAsset: "TUSD",
+  },
+  BNBUSDC: {
+    symbol: "BNBUSDC",
+    baseAsset: "BNB",
+    quoteAsset: "USDC",
+  },
+  BTCUSDC: {
+    symbol: "BTCUSDC",
+    baseAsset: "BTC",
+    quoteAsset: "USDC",
+  },
+  ETHUSDC: {
+    symbol: "ETHUSDC",
+    baseAsset: "ETH",
+    quoteAsset: "USDC",
+  },
+  XRPUSDC: {
+    symbol: "XRPUSDC",
+    baseAsset: "XRP",
+    quoteAsset: "USDC",
+  },
+  EOSUSDC: {
+    symbol: "EOSUSDC",
+    baseAsset: "EOS",
+    quoteAsset: "USDC",
+  },
+  XLMUSDC: {
+    symbol: "XLMUSDC",
+    baseAsset: "XLM",
+    quoteAsset: "USDC",
+  },
+  USDCUSDT: {
+    symbol: "USDCUSDT",
+    baseAsset: "USDC",
+    quoteAsset: "USDT",
+  },
+  ADATUSD: {
+    symbol: "ADATUSD",
+    baseAsset: "ADA",
+    quoteAsset: "TUSD",
+  },
+  TRXTUSD: {
+    symbol: "TRXTUSD",
+    baseAsset: "TRX",
+    quoteAsset: "TUSD",
+  },
+  NEOTUSD: {
+    symbol: "NEOTUSD",
+    baseAsset: "NEO",
+    quoteAsset: "TUSD",
+  },
+  TRXXRP: {
+    symbol: "TRXXRP",
+    baseAsset: "TRX",
+    quoteAsset: "XRP",
+  },
+  XZCXRP: {
+    symbol: "XZCXRP",
+    baseAsset: "XZC",
+    quoteAsset: "XRP",
+  },
+  PAXTUSD: {
+    symbol: "PAXTUSD",
+    baseAsset: "PAX",
+    quoteAsset: "TUSD",
+  },
+  USDCTUSD: {
+    symbol: "USDCTUSD",
+    baseAsset: "USDC",
+    quoteAsset: "TUSD",
+  },
+  USDCPAX: {
+    symbol: "USDCPAX",
+    baseAsset: "USDC",
+    quoteAsset: "PAX",
+  },
+  LINKUSDT: {
+    symbol: "LINKUSDT",
+    baseAsset: "LINK",
+    quoteAsset: "USDT",
+  },
+  LINKTUSD: {
+    symbol: "LINKTUSD",
+    baseAsset: "LINK",
+    quoteAsset: "TUSD",
+  },
+  LINKPAX: {
+    symbol: "LINKPAX",
+    baseAsset: "LINK",
+    quoteAsset: "PAX",
+  },
+  LINKUSDC: {
+    symbol: "LINKUSDC",
+    baseAsset: "LINK",
+    quoteAsset: "USDC",
+  },
+  WAVESUSDT: {
+    symbol: "WAVESUSDT",
+    baseAsset: "WAVES",
+    quoteAsset: "USDT",
+  },
+  WAVESTUSD: {
+    symbol: "WAVESTUSD",
+    baseAsset: "WAVES",
+    quoteAsset: "TUSD",
+  },
+  WAVESPAX: {
+    symbol: "WAVESPAX",
+    baseAsset: "WAVES",
+    quoteAsset: "PAX",
+  },
+  WAVESUSDC: {
+    symbol: "WAVESUSDC",
+    baseAsset: "WAVES",
+    quoteAsset: "USDC",
+  },
+  BCHABCTUSD: {
+    symbol: "BCHABCTUSD",
+    baseAsset: "BCHABC",
+    quoteAsset: "TUSD",
+  },
+  BCHABCPAX: {
+    symbol: "BCHABCPAX",
+    baseAsset: "BCHABC",
+    quoteAsset: "PAX",
+  },
+  BCHABCUSDC: {
+    symbol: "BCHABCUSDC",
+    baseAsset: "BCHABC",
+    quoteAsset: "USDC",
+  },
+  BCHSVTUSD: {
+    symbol: "BCHSVTUSD",
+    baseAsset: "BCHSV",
+    quoteAsset: "TUSD",
+  },
+  BCHSVPAX: {
+    symbol: "BCHSVPAX",
+    baseAsset: "BCHSV",
+    quoteAsset: "PAX",
+  },
+  BCHSVUSDC: {
+    symbol: "BCHSVUSDC",
+    baseAsset: "BCHSV",
+    quoteAsset: "USDC",
+  },
+  LTCTUSD: {
+    symbol: "LTCTUSD",
+    baseAsset: "LTC",
+    quoteAsset: "TUSD",
+  },
+  LTCPAX: {
+    symbol: "LTCPAX",
+    baseAsset: "LTC",
+    quoteAsset: "PAX",
+  },
+  LTCUSDC: {
+    symbol: "LTCUSDC",
+    baseAsset: "LTC",
+    quoteAsset: "USDC",
+  },
+  TRXPAX: {
+    symbol: "TRXPAX",
+    baseAsset: "TRX",
+    quoteAsset: "PAX",
+  },
+  TRXUSDC: {
+    symbol: "TRXUSDC",
+    baseAsset: "TRX",
+    quoteAsset: "USDC",
+  },
+  BTTBTC: {
+    symbol: "BTTBTC",
+    baseAsset: "BTT",
+    quoteAsset: "BTC",
+  },
+  BTTBNB: {
+    symbol: "BTTBNB",
+    baseAsset: "BTT",
+    quoteAsset: "BNB",
+  },
+  BTTUSDT: {
+    symbol: "BTTUSDT",
+    baseAsset: "BTT",
+    quoteAsset: "USDT",
+  },
+  BNBUSDS: {
+    symbol: "BNBUSDS",
+    baseAsset: "BNB",
+    quoteAsset: "USDS",
+  },
+  BTCUSDS: {
+    symbol: "BTCUSDS",
+    baseAsset: "BTC",
+    quoteAsset: "USDS",
+  },
+  USDSUSDT: {
+    symbol: "USDSUSDT",
+    baseAsset: "USDS",
+    quoteAsset: "USDT",
+  },
+  USDSPAX: {
+    symbol: "USDSPAX",
+    baseAsset: "USDS",
+    quoteAsset: "PAX",
+  },
+  USDSTUSD: {
+    symbol: "USDSTUSD",
+    baseAsset: "USDS",
+    quoteAsset: "TUSD",
+  },
+  USDSUSDC: {
+    symbol: "USDSUSDC",
+    baseAsset: "USDS",
+    quoteAsset: "USDC",
+  },
+  BTTPAX: {
+    symbol: "BTTPAX",
+    baseAsset: "BTT",
+    quoteAsset: "PAX",
+  },
+  BTTTUSD: {
+    symbol: "BTTTUSD",
+    baseAsset: "BTT",
+    quoteAsset: "TUSD",
+  },
+  BTTUSDC: {
+    symbol: "BTTUSDC",
+    baseAsset: "BTT",
+    quoteAsset: "USDC",
+  },
+  ONGBNB: {
+    symbol: "ONGBNB",
+    baseAsset: "ONG",
+    quoteAsset: "BNB",
+  },
+  ONGBTC: {
+    symbol: "ONGBTC",
+    baseAsset: "ONG",
+    quoteAsset: "BTC",
+  },
+  ONGUSDT: {
+    symbol: "ONGUSDT",
+    baseAsset: "ONG",
+    quoteAsset: "USDT",
+  },
+  HOTBNB: {
+    symbol: "HOTBNB",
+    baseAsset: "HOT",
+    quoteAsset: "BNB",
+  },
+  HOTUSDT: {
+    symbol: "HOTUSDT",
+    baseAsset: "HOT",
+    quoteAsset: "USDT",
+  },
+  ZILUSDT: {
+    symbol: "ZILUSDT",
+    baseAsset: "ZIL",
+    quoteAsset: "USDT",
+  },
+  ZRXBNB: {
+    symbol: "ZRXBNB",
+    baseAsset: "ZRX",
+    quoteAsset: "BNB",
+  },
+  ZRXUSDT: {
+    symbol: "ZRXUSDT",
+    baseAsset: "ZRX",
+    quoteAsset: "USDT",
+  },
+  FETBNB: {
+    symbol: "FETBNB",
+    baseAsset: "FET",
+    quoteAsset: "BNB",
+  },
+  FETBTC: {
+    symbol: "FETBTC",
+    baseAsset: "FET",
+    quoteAsset: "BTC",
+  },
+  FETUSDT: {
+    symbol: "FETUSDT",
+    baseAsset: "FET",
+    quoteAsset: "USDT",
+  },
+  BATUSDT: {
+    symbol: "BATUSDT",
+    baseAsset: "BAT",
+    quoteAsset: "USDT",
+  },
+  XMRBNB: {
+    symbol: "XMRBNB",
+    baseAsset: "XMR",
+    quoteAsset: "BNB",
+  },
+  XMRUSDT: {
+    symbol: "XMRUSDT",
+    baseAsset: "XMR",
+    quoteAsset: "USDT",
+  },
+  ZECBNB: {
+    symbol: "ZECBNB",
+    baseAsset: "ZEC",
+    quoteAsset: "BNB",
+  },
+  ZECUSDT: {
+    symbol: "ZECUSDT",
+    baseAsset: "ZEC",
+    quoteAsset: "USDT",
+  },
+  ZECPAX: {
+    symbol: "ZECPAX",
+    baseAsset: "ZEC",
+    quoteAsset: "PAX",
+  },
+  ZECTUSD: {
+    symbol: "ZECTUSD",
+    baseAsset: "ZEC",
+    quoteAsset: "TUSD",
+  },
+  ZECUSDC: {
+    symbol: "ZECUSDC",
+    baseAsset: "ZEC",
+    quoteAsset: "USDC",
+  },
+  IOSTBNB: {
+    symbol: "IOSTBNB",
+    baseAsset: "IOST",
+    quoteAsset: "BNB",
+  },
+  IOSTUSDT: {
+    symbol: "IOSTUSDT",
+    baseAsset: "IOST",
+    quoteAsset: "USDT",
+  },
+  CELRBNB: {
+    symbol: "CELRBNB",
+    baseAsset: "CELR",
+    quoteAsset: "BNB",
+  },
+  CELRBTC: {
+    symbol: "CELRBTC",
+    baseAsset: "CELR",
+    quoteAsset: "BTC",
+  },
+  CELRUSDT: {
+    symbol: "CELRUSDT",
+    baseAsset: "CELR",
+    quoteAsset: "USDT",
+  },
+  ADAPAX: {
+    symbol: "ADAPAX",
+    baseAsset: "ADA",
+    quoteAsset: "PAX",
+  },
+  ADAUSDC: {
+    symbol: "ADAUSDC",
+    baseAsset: "ADA",
+    quoteAsset: "USDC",
+  },
+  NEOPAX: {
+    symbol: "NEOPAX",
+    baseAsset: "NEO",
+    quoteAsset: "PAX",
+  },
+  NEOUSDC: {
+    symbol: "NEOUSDC",
+    baseAsset: "NEO",
+    quoteAsset: "USDC",
+  },
+  DASHBNB: {
+    symbol: "DASHBNB",
+    baseAsset: "DASH",
+    quoteAsset: "BNB",
+  },
+  DASHUSDT: {
+    symbol: "DASHUSDT",
+    baseAsset: "DASH",
+    quoteAsset: "USDT",
+  },
+  NANOUSDT: {
+    symbol: "NANOUSDT",
+    baseAsset: "NANO",
+    quoteAsset: "USDT",
+  },
+  OMGBNB: {
+    symbol: "OMGBNB",
+    baseAsset: "OMG",
+    quoteAsset: "BNB",
+  },
+  OMGUSDT: {
+    symbol: "OMGUSDT",
+    baseAsset: "OMG",
+    quoteAsset: "USDT",
+  },
+  THETAUSDT: {
+    symbol: "THETAUSDT",
+    baseAsset: "THETA",
+    quoteAsset: "USDT",
+  },
+  ENJUSDT: {
+    symbol: "ENJUSDT",
+    baseAsset: "ENJ",
+    quoteAsset: "USDT",
+  },
+  MITHUSDT: {
+    symbol: "MITHUSDT",
+    baseAsset: "MITH",
+    quoteAsset: "USDT",
+  },
+  MATICBNB: {
+    symbol: "MATICBNB",
+    baseAsset: "MATIC",
+    quoteAsset: "BNB",
+  },
+  MATICBTC: {
+    symbol: "MATICBTC",
+    baseAsset: "MATIC",
+    quoteAsset: "BTC",
+  },
+  MATICUSDT: {
+    symbol: "MATICUSDT",
+    baseAsset: "MATIC",
+    quoteAsset: "USDT",
+  },
+  ATOMBNB: {
+    symbol: "ATOMBNB",
+    baseAsset: "ATOM",
+    quoteAsset: "BNB",
+  },
+  ATOMBTC: {
+    symbol: "ATOMBTC",
+    baseAsset: "ATOM",
+    quoteAsset: "BTC",
+  },
+  ATOMUSDT: {
+    symbol: "ATOMUSDT",
+    baseAsset: "ATOM",
+    quoteAsset: "USDT",
+  },
+  ATOMUSDC: {
+    symbol: "ATOMUSDC",
+    baseAsset: "ATOM",
+    quoteAsset: "USDC",
+  },
+  ATOMPAX: {
+    symbol: "ATOMPAX",
+    baseAsset: "ATOM",
+    quoteAsset: "PAX",
+  },
+  ATOMTUSD: {
+    symbol: "ATOMTUSD",
+    baseAsset: "ATOM",
+    quoteAsset: "TUSD",
+  },
+  ETCUSDC: {
+    symbol: "ETCUSDC",
+    baseAsset: "ETC",
+    quoteAsset: "USDC",
+  },
+  ETCPAX: {
+    symbol: "ETCPAX",
+    baseAsset: "ETC",
+    quoteAsset: "PAX",
+  },
+  ETCTUSD: {
+    symbol: "ETCTUSD",
+    baseAsset: "ETC",
+    quoteAsset: "TUSD",
+  },
+  BATUSDC: {
+    symbol: "BATUSDC",
+    baseAsset: "BAT",
+    quoteAsset: "USDC",
+  },
+  BATPAX: {
+    symbol: "BATPAX",
+    baseAsset: "BAT",
+    quoteAsset: "PAX",
+  },
+  BATTUSD: {
+    symbol: "BATTUSD",
+    baseAsset: "BAT",
+    quoteAsset: "TUSD",
+  },
+  PHBBNB: {
+    symbol: "PHBBNB",
+    baseAsset: "PHB",
+    quoteAsset: "BNB",
+  },
+  PHBBTC: {
+    symbol: "PHBBTC",
+    baseAsset: "PHB",
+    quoteAsset: "BTC",
+  },
+  PHBUSDC: {
+    symbol: "PHBUSDC",
+    baseAsset: "PHB",
+    quoteAsset: "USDC",
+  },
+  PHBTUSD: {
+    symbol: "PHBTUSD",
+    baseAsset: "PHB",
+    quoteAsset: "TUSD",
+  },
+  PHBPAX: {
+    symbol: "PHBPAX",
+    baseAsset: "PHB",
+    quoteAsset: "PAX",
+  },
+  TFUELBNB: {
+    symbol: "TFUELBNB",
+    baseAsset: "TFUEL",
+    quoteAsset: "BNB",
+  },
+  TFUELBTC: {
+    symbol: "TFUELBTC",
+    baseAsset: "TFUEL",
+    quoteAsset: "BTC",
+  },
+  TFUELUSDT: {
+    symbol: "TFUELUSDT",
+    baseAsset: "TFUEL",
+    quoteAsset: "USDT",
+  },
+  TFUELUSDC: {
+    symbol: "TFUELUSDC",
+    baseAsset: "TFUEL",
+    quoteAsset: "USDC",
+  },
+  TFUELTUSD: {
+    symbol: "TFUELTUSD",
+    baseAsset: "TFUEL",
+    quoteAsset: "TUSD",
+  },
+  TFUELPAX: {
+    symbol: "TFUELPAX",
+    baseAsset: "TFUEL",
+    quoteAsset: "PAX",
+  },
+  ONEBNB: {
+    symbol: "ONEBNB",
+    baseAsset: "ONE",
+    quoteAsset: "BNB",
+  },
+  ONEBTC: {
+    symbol: "ONEBTC",
+    baseAsset: "ONE",
+    quoteAsset: "BTC",
+  },
+  ONEUSDT: {
+    symbol: "ONEUSDT",
+    baseAsset: "ONE",
+    quoteAsset: "USDT",
+  },
+  ONETUSD: {
+    symbol: "ONETUSD",
+    baseAsset: "ONE",
+    quoteAsset: "TUSD",
+  },
+  ONEPAX: {
+    symbol: "ONEPAX",
+    baseAsset: "ONE",
+    quoteAsset: "PAX",
+  },
+  ONEUSDC: {
+    symbol: "ONEUSDC",
+    baseAsset: "ONE",
+    quoteAsset: "USDC",
+  },
+  FTMBNB: {
+    symbol: "FTMBNB",
+    baseAsset: "FTM",
+    quoteAsset: "BNB",
+  },
+  FTMBTC: {
+    symbol: "FTMBTC",
+    baseAsset: "FTM",
+    quoteAsset: "BTC",
+  },
+  FTMUSDT: {
+    symbol: "FTMUSDT",
+    baseAsset: "FTM",
+    quoteAsset: "USDT",
+  },
+  FTMTUSD: {
+    symbol: "FTMTUSD",
+    baseAsset: "FTM",
+    quoteAsset: "TUSD",
+  },
+  FTMPAX: {
+    symbol: "FTMPAX",
+    baseAsset: "FTM",
+    quoteAsset: "PAX",
+  },
+  FTMUSDC: {
+    symbol: "FTMUSDC",
+    baseAsset: "FTM",
+    quoteAsset: "USDC",
+  },
+  BTCBBTC: {
+    symbol: "BTCBBTC",
+    baseAsset: "BTCB",
+    quoteAsset: "BTC",
+  },
+  BCPTTUSD: {
+    symbol: "BCPTTUSD",
+    baseAsset: "BCPT",
+    quoteAsset: "TUSD",
+  },
+  BCPTPAX: {
+    symbol: "BCPTPAX",
+    baseAsset: "BCPT",
+    quoteAsset: "PAX",
+  },
+  BCPTUSDC: {
+    symbol: "BCPTUSDC",
+    baseAsset: "BCPT",
+    quoteAsset: "USDC",
+  },
+  ALGOBNB: {
+    symbol: "ALGOBNB",
+    baseAsset: "ALGO",
+    quoteAsset: "BNB",
+  },
+  ALGOBTC: {
+    symbol: "ALGOBTC",
+    baseAsset: "ALGO",
+    quoteAsset: "BTC",
+  },
+  ALGOUSDT: {
+    symbol: "ALGOUSDT",
+    baseAsset: "ALGO",
+    quoteAsset: "USDT",
+  },
+  ALGOTUSD: {
+    symbol: "ALGOTUSD",
+    baseAsset: "ALGO",
+    quoteAsset: "TUSD",
+  },
+  ALGOPAX: {
+    symbol: "ALGOPAX",
+    baseAsset: "ALGO",
+    quoteAsset: "PAX",
+  },
+  ALGOUSDC: {
+    symbol: "ALGOUSDC",
+    baseAsset: "ALGO",
+    quoteAsset: "USDC",
+  },
+  USDSBUSDT: {
+    symbol: "USDSBUSDT",
+    baseAsset: "USDSB",
+    quoteAsset: "USDT",
+  },
+  USDSBUSDS: {
+    symbol: "USDSBUSDS",
+    baseAsset: "USDSB",
+    quoteAsset: "USDS",
+  },
+  GTOUSDT: {
+    symbol: "GTOUSDT",
+    baseAsset: "GTO",
+    quoteAsset: "USDT",
+  },
+  GTOPAX: {
+    symbol: "GTOPAX",
+    baseAsset: "GTO",
+    quoteAsset: "PAX",
+  },
+  GTOTUSD: {
+    symbol: "GTOTUSD",
+    baseAsset: "GTO",
+    quoteAsset: "TUSD",
+  },
+  GTOUSDC: {
+    symbol: "GTOUSDC",
+    baseAsset: "GTO",
+    quoteAsset: "USDC",
+  },
+  ERDBNB: {
+    symbol: "ERDBNB",
+    baseAsset: "ERD",
+    quoteAsset: "BNB",
+  },
+  ERDBTC: {
+    symbol: "ERDBTC",
+    baseAsset: "ERD",
+    quoteAsset: "BTC",
+  },
+  ERDUSDT: {
+    symbol: "ERDUSDT",
+    baseAsset: "ERD",
+    quoteAsset: "USDT",
+  },
+  ERDPAX: {
+    symbol: "ERDPAX",
+    baseAsset: "ERD",
+    quoteAsset: "PAX",
+  },
+  ERDUSDC: {
+    symbol: "ERDUSDC",
+    baseAsset: "ERD",
+    quoteAsset: "USDC",
+  },
+  DOGEBNB: {
+    symbol: "DOGEBNB",
+    baseAsset: "DOGE",
+    quoteAsset: "BNB",
+  },
+  DOGEBTC: {
+    symbol: "DOGEBTC",
+    baseAsset: "DOGE",
+    quoteAsset: "BTC",
+  },
+  DOGEUSDT: {
+    symbol: "DOGEUSDT",
+    baseAsset: "DOGE",
+    quoteAsset: "USDT",
+  },
+  DOGEPAX: {
+    symbol: "DOGEPAX",
+    baseAsset: "DOGE",
+    quoteAsset: "PAX",
+  },
+  DOGEUSDC: {
+    symbol: "DOGEUSDC",
+    baseAsset: "DOGE",
+    quoteAsset: "USDC",
+  },
+  DUSKBNB: {
+    symbol: "DUSKBNB",
+    baseAsset: "DUSK",
+    quoteAsset: "BNB",
+  },
+  DUSKBTC: {
+    symbol: "DUSKBTC",
+    baseAsset: "DUSK",
+    quoteAsset: "BTC",
+  },
+  DUSKUSDT: {
+    symbol: "DUSKUSDT",
+    baseAsset: "DUSK",
+    quoteAsset: "USDT",
+  },
+  DUSKUSDC: {
+    symbol: "DUSKUSDC",
+    baseAsset: "DUSK",
+    quoteAsset: "USDC",
+  },
+  DUSKPAX: {
+    symbol: "DUSKPAX",
+    baseAsset: "DUSK",
+    quoteAsset: "PAX",
+  },
+  BGBPUSDC: {
+    symbol: "BGBPUSDC",
+    baseAsset: "BGBP",
+    quoteAsset: "USDC",
+  },
+  ANKRBNB: {
+    symbol: "ANKRBNB",
+    baseAsset: "ANKR",
+    quoteAsset: "BNB",
+  },
+  ANKRBTC: {
+    symbol: "ANKRBTC",
+    baseAsset: "ANKR",
+    quoteAsset: "BTC",
+  },
+  ANKRUSDT: {
+    symbol: "ANKRUSDT",
+    baseAsset: "ANKR",
+    quoteAsset: "USDT",
+  },
+  ANKRTUSD: {
+    symbol: "ANKRTUSD",
+    baseAsset: "ANKR",
+    quoteAsset: "TUSD",
+  },
+  ANKRPAX: {
+    symbol: "ANKRPAX",
+    baseAsset: "ANKR",
+    quoteAsset: "PAX",
+  },
+  ANKRUSDC: {
+    symbol: "ANKRUSDC",
+    baseAsset: "ANKR",
+    quoteAsset: "USDC",
+  },
+  ONTPAX: {
+    symbol: "ONTPAX",
+    baseAsset: "ONT",
+    quoteAsset: "PAX",
+  },
+  ONTUSDC: {
+    symbol: "ONTUSDC",
+    baseAsset: "ONT",
+    quoteAsset: "USDC",
+  },
+  WINBNB: {
+    symbol: "WINBNB",
+    baseAsset: "WIN",
+    quoteAsset: "BNB",
+  },
+  WINBTC: {
+    symbol: "WINBTC",
+    baseAsset: "WIN",
+    quoteAsset: "BTC",
+  },
+  WINUSDT: {
+    symbol: "WINUSDT",
+    baseAsset: "WIN",
+    quoteAsset: "USDT",
+  },
+  WINUSDC: {
+    symbol: "WINUSDC",
+    baseAsset: "WIN",
+    quoteAsset: "USDC",
+  },
+  COSBNB: {
+    symbol: "COSBNB",
+    baseAsset: "COS",
+    quoteAsset: "BNB",
+  },
+  COSBTC: {
+    symbol: "COSBTC",
+    baseAsset: "COS",
+    quoteAsset: "BTC",
+  },
+  COSUSDT: {
+    symbol: "COSUSDT",
+    baseAsset: "COS",
+    quoteAsset: "USDT",
+  },
+  TUSDBTUSD: {
+    symbol: "TUSDBTUSD",
+    baseAsset: "TUSDB",
+    quoteAsset: "TUSD",
+  },
+  NPXSUSDT: {
+    symbol: "NPXSUSDT",
+    baseAsset: "NPXS",
+    quoteAsset: "USDT",
+  },
+  NPXSUSDC: {
+    symbol: "NPXSUSDC",
+    baseAsset: "NPXS",
+    quoteAsset: "USDC",
+  },
+  COCOSBNB: {
+    symbol: "COCOSBNB",
+    baseAsset: "COCOS",
+    quoteAsset: "BNB",
+  },
+  COCOSBTC: {
+    symbol: "COCOSBTC",
+    baseAsset: "COCOS",
+    quoteAsset: "BTC",
+  },
+  COCOSUSDT: {
+    symbol: "COCOSUSDT",
+    baseAsset: "COCOS",
+    quoteAsset: "USDT",
+  },
+  MTLUSDT: {
+    symbol: "MTLUSDT",
+    baseAsset: "MTL",
+    quoteAsset: "USDT",
+  },
+  TOMOBNB: {
+    symbol: "TOMOBNB",
+    baseAsset: "TOMO",
+    quoteAsset: "BNB",
+  },
+  TOMOBTC: {
+    symbol: "TOMOBTC",
+    baseAsset: "TOMO",
+    quoteAsset: "BTC",
+  },
+  TOMOUSDT: {
+    symbol: "TOMOUSDT",
+    baseAsset: "TOMO",
+    quoteAsset: "USDT",
+  },
+  TOMOUSDC: {
+    symbol: "TOMOUSDC",
+    baseAsset: "TOMO",
+    quoteAsset: "USDC",
+  },
+  PERLBNB: {
+    symbol: "PERLBNB",
+    baseAsset: "PERL",
+    quoteAsset: "BNB",
+  },
+  PERLBTC: {
+    symbol: "PERLBTC",
+    baseAsset: "PERL",
+    quoteAsset: "BTC",
+  },
+  PERLUSDC: {
+    symbol: "PERLUSDC",
+    baseAsset: "PERL",
+    quoteAsset: "USDC",
+  },
+  PERLUSDT: {
+    symbol: "PERLUSDT",
+    baseAsset: "PERL",
+    quoteAsset: "USDT",
+  },
+  DENTUSDT: {
+    symbol: "DENTUSDT",
+    baseAsset: "DENT",
+    quoteAsset: "USDT",
+  },
+  MFTUSDT: {
+    symbol: "MFTUSDT",
+    baseAsset: "MFT",
+    quoteAsset: "USDT",
+  },
+  KEYUSDT: {
+    symbol: "KEYUSDT",
+    baseAsset: "KEY",
+    quoteAsset: "USDT",
+  },
+  STORMUSDT: {
+    symbol: "STORMUSDT",
+    baseAsset: "STORM",
+    quoteAsset: "USDT",
+  },
+  DOCKUSDT: {
+    symbol: "DOCKUSDT",
+    baseAsset: "DOCK",
+    quoteAsset: "USDT",
+  },
+  WANUSDT: {
+    symbol: "WANUSDT",
+    baseAsset: "WAN",
+    quoteAsset: "USDT",
+  },
+  FUNUSDT: {
+    symbol: "FUNUSDT",
+    baseAsset: "FUN",
+    quoteAsset: "USDT",
+  },
+  CVCUSDT: {
+    symbol: "CVCUSDT",
+    baseAsset: "CVC",
+    quoteAsset: "USDT",
+  },
+  BTTTRX: {
+    symbol: "BTTTRX",
+    baseAsset: "BTT",
+    quoteAsset: "TRX",
+  },
+  WINTRX: {
+    symbol: "WINTRX",
+    baseAsset: "WIN",
+    quoteAsset: "TRX",
+  },
+  CHZBNB: {
+    symbol: "CHZBNB",
+    baseAsset: "CHZ",
+    quoteAsset: "BNB",
+  },
+  CHZBTC: {
+    symbol: "CHZBTC",
+    baseAsset: "CHZ",
+    quoteAsset: "BTC",
+  },
+  CHZUSDT: {
+    symbol: "CHZUSDT",
+    baseAsset: "CHZ",
+    quoteAsset: "USDT",
+  },
+  BANDBNB: {
+    symbol: "BANDBNB",
+    baseAsset: "BAND",
+    quoteAsset: "BNB",
+  },
+  BANDBTC: {
+    symbol: "BANDBTC",
+    baseAsset: "BAND",
+    quoteAsset: "BTC",
+  },
+  BANDUSDT: {
+    symbol: "BANDUSDT",
+    baseAsset: "BAND",
+    quoteAsset: "USDT",
+  },
+  BNBBUSD: {
+    symbol: "BNBBUSD",
+    baseAsset: "BNB",
+    quoteAsset: "BUSD",
+  },
+  BTCBUSD: {
+    symbol: "BTCBUSD",
+    baseAsset: "BTC",
+    quoteAsset: "BUSD",
+  },
+  BUSDUSDT: {
+    symbol: "BUSDUSDT",
+    baseAsset: "BUSD",
+    quoteAsset: "USDT",
+  },
+  BEAMBNB: {
+    symbol: "BEAMBNB",
+    baseAsset: "BEAM",
+    quoteAsset: "BNB",
+  },
+  BEAMBTC: {
+    symbol: "BEAMBTC",
+    baseAsset: "BEAM",
+    quoteAsset: "BTC",
+  },
+  BEAMUSDT: {
+    symbol: "BEAMUSDT",
+    baseAsset: "BEAM",
+    quoteAsset: "USDT",
+  },
+  XTZBNB: {
+    symbol: "XTZBNB",
+    baseAsset: "XTZ",
+    quoteAsset: "BNB",
+  },
+  XTZBTC: {
+    symbol: "XTZBTC",
+    baseAsset: "XTZ",
+    quoteAsset: "BTC",
+  },
+  XTZUSDT: {
+    symbol: "XTZUSDT",
+    baseAsset: "XTZ",
+    quoteAsset: "USDT",
+  },
+  RENUSDT: {
+    symbol: "RENUSDT",
+    baseAsset: "REN",
+    quoteAsset: "USDT",
+  },
+  RVNUSDT: {
+    symbol: "RVNUSDT",
+    baseAsset: "RVN",
+    quoteAsset: "USDT",
+  },
+  HCUSDT: {
+    symbol: "HCUSDT",
+    baseAsset: "HC",
+    quoteAsset: "USDT",
+  },
+  HBARBNB: {
+    symbol: "HBARBNB",
+    baseAsset: "HBAR",
+    quoteAsset: "BNB",
+  },
+  HBARBTC: {
+    symbol: "HBARBTC",
+    baseAsset: "HBAR",
+    quoteAsset: "BTC",
+  },
+  HBARUSDT: {
+    symbol: "HBARUSDT",
+    baseAsset: "HBAR",
+    quoteAsset: "USDT",
+  },
+  NKNBNB: {
+    symbol: "NKNBNB",
+    baseAsset: "NKN",
+    quoteAsset: "BNB",
+  },
+  NKNBTC: {
+    symbol: "NKNBTC",
+    baseAsset: "NKN",
+    quoteAsset: "BTC",
+  },
+  NKNUSDT: {
+    symbol: "NKNUSDT",
+    baseAsset: "NKN",
+    quoteAsset: "USDT",
+  },
+  XRPBUSD: {
+    symbol: "XRPBUSD",
+    baseAsset: "XRP",
+    quoteAsset: "BUSD",
+  },
+  ETHBUSD: {
+    symbol: "ETHBUSD",
+    baseAsset: "ETH",
+    quoteAsset: "BUSD",
+  },
+  BCHABCBUSD: {
+    symbol: "BCHABCBUSD",
+    baseAsset: "BCHABC",
+    quoteAsset: "BUSD",
+  },
+  LTCBUSD: {
+    symbol: "LTCBUSD",
+    baseAsset: "LTC",
+    quoteAsset: "BUSD",
+  },
+  LINKBUSD: {
+    symbol: "LINKBUSD",
+    baseAsset: "LINK",
+    quoteAsset: "BUSD",
+  },
+  ETCBUSD: {
+    symbol: "ETCBUSD",
+    baseAsset: "ETC",
+    quoteAsset: "BUSD",
+  },
+  STXBNB: {
+    symbol: "STXBNB",
+    baseAsset: "STX",
+    quoteAsset: "BNB",
+  },
+  STXBTC: {
+    symbol: "STXBTC",
+    baseAsset: "STX",
+    quoteAsset: "BTC",
+  },
+  STXUSDT: {
+    symbol: "STXUSDT",
+    baseAsset: "STX",
+    quoteAsset: "USDT",
+  },
+  KAVABNB: {
+    symbol: "KAVABNB",
+    baseAsset: "KAVA",
+    quoteAsset: "BNB",
+  },
+  KAVABTC: {
+    symbol: "KAVABTC",
+    baseAsset: "KAVA",
+    quoteAsset: "BTC",
+  },
+  KAVAUSDT: {
+    symbol: "KAVAUSDT",
+    baseAsset: "KAVA",
+    quoteAsset: "USDT",
+  },
+  BUSDNGN: {
+    symbol: "BUSDNGN",
+    baseAsset: "BUSD",
+    quoteAsset: "NGN",
+  },
+  BNBNGN: {
+    symbol: "BNBNGN",
+    baseAsset: "BNB",
+    quoteAsset: "NGN",
+  },
+  BTCNGN: {
+    symbol: "BTCNGN",
+    baseAsset: "BTC",
+    quoteAsset: "NGN",
+  },
+  ARPABNB: {
+    symbol: "ARPABNB",
+    baseAsset: "ARPA",
+    quoteAsset: "BNB",
+  },
+  ARPABTC: {
+    symbol: "ARPABTC",
+    baseAsset: "ARPA",
+    quoteAsset: "BTC",
+  },
+  ARPAUSDT: {
+    symbol: "ARPAUSDT",
+    baseAsset: "ARPA",
+    quoteAsset: "USDT",
+  },
+  TRXBUSD: {
+    symbol: "TRXBUSD",
+    baseAsset: "TRX",
+    quoteAsset: "BUSD",
+  },
+  EOSBUSD: {
+    symbol: "EOSBUSD",
+    baseAsset: "EOS",
+    quoteAsset: "BUSD",
+  },
+  IOTXUSDT: {
+    symbol: "IOTXUSDT",
+    baseAsset: "IOTX",
+    quoteAsset: "USDT",
+  },
+  RLCUSDT: {
+    symbol: "RLCUSDT",
+    baseAsset: "RLC",
+    quoteAsset: "USDT",
+  },
+  MCOUSDT: {
+    symbol: "MCOUSDT",
+    baseAsset: "MCO",
+    quoteAsset: "USDT",
+  },
+  XLMBUSD: {
+    symbol: "XLMBUSD",
+    baseAsset: "XLM",
+    quoteAsset: "BUSD",
+  },
+  ADABUSD: {
+    symbol: "ADABUSD",
+    baseAsset: "ADA",
+    quoteAsset: "BUSD",
+  },
+  CTXCBNB: {
+    symbol: "CTXCBNB",
+    baseAsset: "CTXC",
+    quoteAsset: "BNB",
+  },
+  CTXCBTC: {
+    symbol: "CTXCBTC",
+    baseAsset: "CTXC",
+    quoteAsset: "BTC",
+  },
+  CTXCUSDT: {
+    symbol: "CTXCUSDT",
+    baseAsset: "CTXC",
+    quoteAsset: "USDT",
+  },
+  BCHBNB: {
+    symbol: "BCHBNB",
+    baseAsset: "BCH",
+    quoteAsset: "BNB",
+  },
+  BCHBTC: {
+    symbol: "BCHBTC",
+    baseAsset: "BCH",
+    quoteAsset: "BTC",
+  },
+  BCHUSDT: {
+    symbol: "BCHUSDT",
+    baseAsset: "BCH",
+    quoteAsset: "USDT",
+  },
+  BCHUSDC: {
+    symbol: "BCHUSDC",
+    baseAsset: "BCH",
+    quoteAsset: "USDC",
+  },
+  BCHTUSD: {
+    symbol: "BCHTUSD",
+    baseAsset: "BCH",
+    quoteAsset: "TUSD",
+  },
+  BCHPAX: {
+    symbol: "BCHPAX",
+    baseAsset: "BCH",
+    quoteAsset: "PAX",
+  },
+  BCHBUSD: {
+    symbol: "BCHBUSD",
+    baseAsset: "BCH",
+    quoteAsset: "BUSD",
+  },
+  BTCRUB: {
+    symbol: "BTCRUB",
+    baseAsset: "BTC",
+    quoteAsset: "RUB",
+  },
+  ETHRUB: {
+    symbol: "ETHRUB",
+    baseAsset: "ETH",
+    quoteAsset: "RUB",
+  },
+  XRPRUB: {
+    symbol: "XRPRUB",
+    baseAsset: "XRP",
+    quoteAsset: "RUB",
+  },
+  BNBRUB: {
+    symbol: "BNBRUB",
+    baseAsset: "BNB",
+    quoteAsset: "RUB",
+  },
+  TROYBNB: {
+    symbol: "TROYBNB",
+    baseAsset: "TROY",
+    quoteAsset: "BNB",
+  },
+  TROYBTC: {
+    symbol: "TROYBTC",
+    baseAsset: "TROY",
+    quoteAsset: "BTC",
+  },
+  TROYUSDT: {
+    symbol: "TROYUSDT",
+    baseAsset: "TROY",
+    quoteAsset: "USDT",
+  },
+  BUSDRUB: {
+    symbol: "BUSDRUB",
+    baseAsset: "BUSD",
+    quoteAsset: "RUB",
+  },
+  QTUMBUSD: {
+    symbol: "QTUMBUSD",
+    baseAsset: "QTUM",
+    quoteAsset: "BUSD",
+  },
+  VETBUSD: {
+    symbol: "VETBUSD",
+    baseAsset: "VET",
+    quoteAsset: "BUSD",
+  },
+  VITEBNB: {
+    symbol: "VITEBNB",
+    baseAsset: "VITE",
+    quoteAsset: "BNB",
+  },
+  VITEBTC: {
+    symbol: "VITEBTC",
+    baseAsset: "VITE",
+    quoteAsset: "BTC",
+  },
+  VITEUSDT: {
+    symbol: "VITEUSDT",
+    baseAsset: "VITE",
+    quoteAsset: "USDT",
+  },
+  FTTBNB: {
+    symbol: "FTTBNB",
+    baseAsset: "FTT",
+    quoteAsset: "BNB",
+  },
+  FTTBTC: {
+    symbol: "FTTBTC",
+    baseAsset: "FTT",
+    quoteAsset: "BTC",
+  },
+  FTTUSDT: {
+    symbol: "FTTUSDT",
+    baseAsset: "FTT",
+    quoteAsset: "USDT",
+  },
+  BTCTRY: {
+    symbol: "BTCTRY",
+    baseAsset: "BTC",
+    quoteAsset: "TRY",
+  },
+  BNBTRY: {
+    symbol: "BNBTRY",
+    baseAsset: "BNB",
+    quoteAsset: "TRY",
+  },
+  BUSDTRY: {
+    symbol: "BUSDTRY",
+    baseAsset: "BUSD",
+    quoteAsset: "TRY",
+  },
+  ETHTRY: {
+    symbol: "ETHTRY",
+    baseAsset: "ETH",
+    quoteAsset: "TRY",
+  },
+  XRPTRY: {
+    symbol: "XRPTRY",
+    baseAsset: "XRP",
+    quoteAsset: "TRY",
+  },
+  USDTTRY: {
+    symbol: "USDTTRY",
+    baseAsset: "USDT",
+    quoteAsset: "TRY",
+  },
+  USDTRUB: {
+    symbol: "USDTRUB",
+    baseAsset: "USDT",
+    quoteAsset: "RUB",
+  },
+  BTCEUR: {
+    symbol: "BTCEUR",
+    baseAsset: "BTC",
+    quoteAsset: "EUR",
+  },
+  ETHEUR: {
+    symbol: "ETHEUR",
+    baseAsset: "ETH",
+    quoteAsset: "EUR",
+  },
+  BNBEUR: {
+    symbol: "BNBEUR",
+    baseAsset: "BNB",
+    quoteAsset: "EUR",
+  },
+  XRPEUR: {
+    symbol: "XRPEUR",
+    baseAsset: "XRP",
+    quoteAsset: "EUR",
+  },
+  EURBUSD: {
+    symbol: "EURBUSD",
+    baseAsset: "EUR",
+    quoteAsset: "BUSD",
+  },
+  EURUSDT: {
+    symbol: "EURUSDT",
+    baseAsset: "EUR",
+    quoteAsset: "USDT",
+  },
+  OGNBNB: {
+    symbol: "OGNBNB",
+    baseAsset: "OGN",
+    quoteAsset: "BNB",
+  },
+  OGNBTC: {
+    symbol: "OGNBTC",
+    baseAsset: "OGN",
+    quoteAsset: "BTC",
+  },
+  OGNUSDT: {
+    symbol: "OGNUSDT",
+    baseAsset: "OGN",
+    quoteAsset: "USDT",
+  },
+  DREPBNB: {
+    symbol: "DREPBNB",
+    baseAsset: "DREP",
+    quoteAsset: "BNB",
+  },
+  DREPBTC: {
+    symbol: "DREPBTC",
+    baseAsset: "DREP",
+    quoteAsset: "BTC",
+  },
+  DREPUSDT: {
+    symbol: "DREPUSDT",
+    baseAsset: "DREP",
+    quoteAsset: "USDT",
+  },
+  BULLUSDT: {
+    symbol: "BULLUSDT",
+    baseAsset: "BULL",
+    quoteAsset: "USDT",
+  },
+  BULLBUSD: {
+    symbol: "BULLBUSD",
+    baseAsset: "BULL",
+    quoteAsset: "BUSD",
+  },
+  BEARUSDT: {
+    symbol: "BEARUSDT",
+    baseAsset: "BEAR",
+    quoteAsset: "USDT",
+  },
+  BEARBUSD: {
+    symbol: "BEARBUSD",
+    baseAsset: "BEAR",
+    quoteAsset: "BUSD",
+  },
+  ETHBULLUSDT: {
+    symbol: "ETHBULLUSDT",
+    baseAsset: "ETHBULL",
+    quoteAsset: "USDT",
+  },
+  ETHBULLBUSD: {
+    symbol: "ETHBULLBUSD",
+    baseAsset: "ETHBULL",
+    quoteAsset: "BUSD",
+  },
+  ETHBEARUSDT: {
+    symbol: "ETHBEARUSDT",
+    baseAsset: "ETHBEAR",
+    quoteAsset: "USDT",
+  },
+  ETHBEARBUSD: {
+    symbol: "ETHBEARBUSD",
+    baseAsset: "ETHBEAR",
+    quoteAsset: "BUSD",
+  },
+  TCTBNB: {
+    symbol: "TCTBNB",
+    baseAsset: "TCT",
+    quoteAsset: "BNB",
+  },
+  TCTBTC: {
+    symbol: "TCTBTC",
+    baseAsset: "TCT",
+    quoteAsset: "BTC",
+  },
+  TCTUSDT: {
+    symbol: "TCTUSDT",
+    baseAsset: "TCT",
+    quoteAsset: "USDT",
+  },
+  WRXBNB: {
+    symbol: "WRXBNB",
+    baseAsset: "WRX",
+    quoteAsset: "BNB",
+  },
+  WRXBTC: {
+    symbol: "WRXBTC",
+    baseAsset: "WRX",
+    quoteAsset: "BTC",
+  },
+  WRXUSDT: {
+    symbol: "WRXUSDT",
+    baseAsset: "WRX",
+    quoteAsset: "USDT",
+  },
+  ICXBUSD: {
+    symbol: "ICXBUSD",
+    baseAsset: "ICX",
+    quoteAsset: "BUSD",
+  },
+  BTSUSDT: {
+    symbol: "BTSUSDT",
+    baseAsset: "BTS",
+    quoteAsset: "USDT",
+  },
+  BTSBUSD: {
+    symbol: "BTSBUSD",
+    baseAsset: "BTS",
+    quoteAsset: "BUSD",
+  },
+  LSKUSDT: {
+    symbol: "LSKUSDT",
+    baseAsset: "LSK",
+    quoteAsset: "USDT",
+  },
+  BNTUSDT: {
+    symbol: "BNTUSDT",
+    baseAsset: "BNT",
+    quoteAsset: "USDT",
+  },
+  BNTBUSD: {
+    symbol: "BNTBUSD",
+    baseAsset: "BNT",
+    quoteAsset: "BUSD",
+  },
+  LTOBNB: {
+    symbol: "LTOBNB",
+    baseAsset: "LTO",
+    quoteAsset: "BNB",
+  },
+  LTOBTC: {
+    symbol: "LTOBTC",
+    baseAsset: "LTO",
+    quoteAsset: "BTC",
+  },
+  LTOUSDT: {
+    symbol: "LTOUSDT",
+    baseAsset: "LTO",
+    quoteAsset: "USDT",
+  },
+  ATOMBUSD: {
+    symbol: "ATOMBUSD",
+    baseAsset: "ATOM",
+    quoteAsset: "BUSD",
+  },
+  DASHBUSD: {
+    symbol: "DASHBUSD",
+    baseAsset: "DASH",
+    quoteAsset: "BUSD",
+  },
+  NEOBUSD: {
+    symbol: "NEOBUSD",
+    baseAsset: "NEO",
+    quoteAsset: "BUSD",
+  },
+  WAVESBUSD: {
+    symbol: "WAVESBUSD",
+    baseAsset: "WAVES",
+    quoteAsset: "BUSD",
+  },
+  XTZBUSD: {
+    symbol: "XTZBUSD",
+    baseAsset: "XTZ",
+    quoteAsset: "BUSD",
+  },
+  EOSBULLUSDT: {
+    symbol: "EOSBULLUSDT",
+    baseAsset: "EOSBULL",
+    quoteAsset: "USDT",
+  },
+  EOSBULLBUSD: {
+    symbol: "EOSBULLBUSD",
+    baseAsset: "EOSBULL",
+    quoteAsset: "BUSD",
+  },
+  EOSBEARUSDT: {
+    symbol: "EOSBEARUSDT",
+    baseAsset: "EOSBEAR",
+    quoteAsset: "USDT",
+  },
+  EOSBEARBUSD: {
+    symbol: "EOSBEARBUSD",
+    baseAsset: "EOSBEAR",
+    quoteAsset: "BUSD",
+  },
+  XRPBULLUSDT: {
+    symbol: "XRPBULLUSDT",
+    baseAsset: "XRPBULL",
+    quoteAsset: "USDT",
+  },
+  XRPBULLBUSD: {
+    symbol: "XRPBULLBUSD",
+    baseAsset: "XRPBULL",
+    quoteAsset: "BUSD",
+  },
+  XRPBEARUSDT: {
+    symbol: "XRPBEARUSDT",
+    baseAsset: "XRPBEAR",
+    quoteAsset: "USDT",
+  },
+  XRPBEARBUSD: {
+    symbol: "XRPBEARBUSD",
+    baseAsset: "XRPBEAR",
+    quoteAsset: "BUSD",
+  },
+  BATBUSD: {
+    symbol: "BATBUSD",
+    baseAsset: "BAT",
+    quoteAsset: "BUSD",
+  },
+  ENJBUSD: {
+    symbol: "ENJBUSD",
+    baseAsset: "ENJ",
+    quoteAsset: "BUSD",
+  },
+  NANOBUSD: {
+    symbol: "NANOBUSD",
+    baseAsset: "NANO",
+    quoteAsset: "BUSD",
+  },
+  ONTBUSD: {
+    symbol: "ONTBUSD",
+    baseAsset: "ONT",
+    quoteAsset: "BUSD",
+  },
+  RVNBUSD: {
+    symbol: "RVNBUSD",
+    baseAsset: "RVN",
+    quoteAsset: "BUSD",
+  },
+  STRATBUSD: {
+    symbol: "STRATBUSD",
+    baseAsset: "STRAT",
+    quoteAsset: "BUSD",
+  },
+  STRATBNB: {
+    symbol: "STRATBNB",
+    baseAsset: "STRAT",
+    quoteAsset: "BNB",
+  },
+  STRATUSDT: {
+    symbol: "STRATUSDT",
+    baseAsset: "STRAT",
+    quoteAsset: "USDT",
+  },
+  AIONBUSD: {
+    symbol: "AIONBUSD",
+    baseAsset: "AION",
+    quoteAsset: "BUSD",
+  },
+  AIONUSDT: {
+    symbol: "AIONUSDT",
+    baseAsset: "AION",
+    quoteAsset: "USDT",
+  },
+  MBLBNB: {
+    symbol: "MBLBNB",
+    baseAsset: "MBL",
+    quoteAsset: "BNB",
+  },
+  MBLBTC: {
+    symbol: "MBLBTC",
+    baseAsset: "MBL",
+    quoteAsset: "BTC",
+  },
+  MBLUSDT: {
+    symbol: "MBLUSDT",
+    baseAsset: "MBL",
+    quoteAsset: "USDT",
+  },
+  COTIBNB: {
+    symbol: "COTIBNB",
+    baseAsset: "COTI",
+    quoteAsset: "BNB",
+  },
+  COTIBTC: {
+    symbol: "COTIBTC",
+    baseAsset: "COTI",
+    quoteAsset: "BTC",
+  },
+  COTIUSDT: {
+    symbol: "COTIUSDT",
+    baseAsset: "COTI",
+    quoteAsset: "USDT",
+  },
+  ALGOBUSD: {
+    symbol: "ALGOBUSD",
+    baseAsset: "ALGO",
+    quoteAsset: "BUSD",
+  },
+  BTTBUSD: {
+    symbol: "BTTBUSD",
+    baseAsset: "BTT",
+    quoteAsset: "BUSD",
+  },
+  TOMOBUSD: {
+    symbol: "TOMOBUSD",
+    baseAsset: "TOMO",
+    quoteAsset: "BUSD",
+  },
+  XMRBUSD: {
+    symbol: "XMRBUSD",
+    baseAsset: "XMR",
+    quoteAsset: "BUSD",
+  },
+  ZECBUSD: {
+    symbol: "ZECBUSD",
+    baseAsset: "ZEC",
+    quoteAsset: "BUSD",
+  },
+  BNBBULLUSDT: {
+    symbol: "BNBBULLUSDT",
+    baseAsset: "BNBBULL",
+    quoteAsset: "USDT",
+  },
+  BNBBULLBUSD: {
+    symbol: "BNBBULLBUSD",
+    baseAsset: "BNBBULL",
+    quoteAsset: "BUSD",
+  },
+  BNBBEARUSDT: {
+    symbol: "BNBBEARUSDT",
+    baseAsset: "BNBBEAR",
+    quoteAsset: "USDT",
+  },
+  BNBBEARBUSD: {
+    symbol: "BNBBEARBUSD",
+    baseAsset: "BNBBEAR",
+    quoteAsset: "BUSD",
+  },
+  STPTBNB: {
+    symbol: "STPTBNB",
+    baseAsset: "STPT",
+    quoteAsset: "BNB",
+  },
+  STPTBTC: {
+    symbol: "STPTBTC",
+    baseAsset: "STPT",
+    quoteAsset: "BTC",
+  },
+  STPTUSDT: {
+    symbol: "STPTUSDT",
+    baseAsset: "STPT",
+    quoteAsset: "USDT",
+  },
+  BTCZAR: {
+    symbol: "BTCZAR",
+    baseAsset: "BTC",
+    quoteAsset: "ZAR",
+  },
+  ETHZAR: {
+    symbol: "ETHZAR",
+    baseAsset: "ETH",
+    quoteAsset: "ZAR",
+  },
+  BNBZAR: {
+    symbol: "BNBZAR",
+    baseAsset: "BNB",
+    quoteAsset: "ZAR",
+  },
+  USDTZAR: {
+    symbol: "USDTZAR",
+    baseAsset: "USDT",
+    quoteAsset: "ZAR",
+  },
+  BUSDZAR: {
+    symbol: "BUSDZAR",
+    baseAsset: "BUSD",
+    quoteAsset: "ZAR",
+  },
+  BTCBKRW: {
+    symbol: "BTCBKRW",
+    baseAsset: "BTC",
+    quoteAsset: "BKRW",
+  },
+  ETHBKRW: {
+    symbol: "ETHBKRW",
+    baseAsset: "ETH",
+    quoteAsset: "BKRW",
+  },
+  BNBBKRW: {
+    symbol: "BNBBKRW",
+    baseAsset: "BNB",
+    quoteAsset: "BKRW",
+  },
+  WTCUSDT: {
+    symbol: "WTCUSDT",
+    baseAsset: "WTC",
+    quoteAsset: "USDT",
+  },
+  DATABUSD: {
+    symbol: "DATABUSD",
+    baseAsset: "DATA",
+    quoteAsset: "BUSD",
+  },
+  DATAUSDT: {
+    symbol: "DATAUSDT",
+    baseAsset: "DATA",
+    quoteAsset: "USDT",
+  },
+  XZCUSDT: {
+    symbol: "XZCUSDT",
+    baseAsset: "XZC",
+    quoteAsset: "USDT",
+  },
+  SOLBNB: {
+    symbol: "SOLBNB",
+    baseAsset: "SOL",
+    quoteAsset: "BNB",
+  },
+  SOLBTC: {
+    symbol: "SOLBTC",
+    baseAsset: "SOL",
+    quoteAsset: "BTC",
+  },
+  SOLUSDT: {
+    symbol: "SOLUSDT",
+    baseAsset: "SOL",
+    quoteAsset: "USDT",
+  },
+  SOLBUSD: {
+    symbol: "SOLBUSD",
+    baseAsset: "SOL",
+    quoteAsset: "BUSD",
+  },
+  BTCIDRT: {
+    symbol: "BTCIDRT",
+    baseAsset: "BTC",
+    quoteAsset: "IDRT",
+  },
+  BNBIDRT: {
+    symbol: "BNBIDRT",
+    baseAsset: "BNB",
+    quoteAsset: "IDRT",
+  },
+  USDTIDRT: {
+    symbol: "USDTIDRT",
+    baseAsset: "USDT",
+    quoteAsset: "IDRT",
+  },
+  BUSDIDRT: {
+    symbol: "BUSDIDRT",
+    baseAsset: "BUSD",
+    quoteAsset: "IDRT",
+  },
+  CTSIBTC: {
+    symbol: "CTSIBTC",
+    baseAsset: "CTSI",
+    quoteAsset: "BTC",
+  },
+  CTSIUSDT: {
+    symbol: "CTSIUSDT",
+    baseAsset: "CTSI",
+    quoteAsset: "USDT",
+  },
+  CTSIBNB: {
+    symbol: "CTSIBNB",
+    baseAsset: "CTSI",
+    quoteAsset: "BNB",
+  },
+  CTSIBUSD: {
+    symbol: "CTSIBUSD",
+    baseAsset: "CTSI",
+    quoteAsset: "BUSD",
+  },
+  HIVEBNB: {
+    symbol: "HIVEBNB",
+    baseAsset: "HIVE",
+    quoteAsset: "BNB",
+  },
+  HIVEBTC: {
+    symbol: "HIVEBTC",
+    baseAsset: "HIVE",
+    quoteAsset: "BTC",
+  },
+  HIVEUSDT: {
+    symbol: "HIVEUSDT",
+    baseAsset: "HIVE",
+    quoteAsset: "USDT",
+  },
+  CHRBNB: {
+    symbol: "CHRBNB",
+    baseAsset: "CHR",
+    quoteAsset: "BNB",
+  },
+  CHRBTC: {
+    symbol: "CHRBTC",
+    baseAsset: "CHR",
+    quoteAsset: "BTC",
+  },
+  CHRUSDT: {
+    symbol: "CHRUSDT",
+    baseAsset: "CHR",
+    quoteAsset: "USDT",
+  },
+  BTCUPUSDT: {
+    symbol: "BTCUPUSDT",
+    baseAsset: "BTCUP",
+    quoteAsset: "USDT",
+  },
+  BTCDOWNUSDT: {
+    symbol: "BTCDOWNUSDT",
+    baseAsset: "BTCDOWN",
+    quoteAsset: "USDT",
+  },
+  GXSUSDT: {
+    symbol: "GXSUSDT",
+    baseAsset: "GXS",
+    quoteAsset: "USDT",
+  },
+  ARDRUSDT: {
+    symbol: "ARDRUSDT",
+    baseAsset: "ARDR",
+    quoteAsset: "USDT",
+  },
+  ERDBUSD: {
+    symbol: "ERDBUSD",
+    baseAsset: "ERD",
+    quoteAsset: "BUSD",
+  },
+  LENDUSDT: {
+    symbol: "LENDUSDT",
+    baseAsset: "LEND",
+    quoteAsset: "USDT",
+  },
+  HBARBUSD: {
+    symbol: "HBARBUSD",
+    baseAsset: "HBAR",
+    quoteAsset: "BUSD",
+  },
+  MATICBUSD: {
+    symbol: "MATICBUSD",
+    baseAsset: "MATIC",
+    quoteAsset: "BUSD",
+  },
+  WRXBUSD: {
+    symbol: "WRXBUSD",
+    baseAsset: "WRX",
+    quoteAsset: "BUSD",
+  },
+  ZILBUSD: {
+    symbol: "ZILBUSD",
+    baseAsset: "ZIL",
+    quoteAsset: "BUSD",
+  },
+  MDTBNB: {
+    symbol: "MDTBNB",
+    baseAsset: "MDT",
+    quoteAsset: "BNB",
+  },
+  MDTBTC: {
+    symbol: "MDTBTC",
+    baseAsset: "MDT",
+    quoteAsset: "BTC",
+  },
+  MDTUSDT: {
+    symbol: "MDTUSDT",
+    baseAsset: "MDT",
+    quoteAsset: "USDT",
+  },
+  STMXBNB: {
+    symbol: "STMXBNB",
+    baseAsset: "STMX",
+    quoteAsset: "BNB",
+  },
+  STMXBTC: {
+    symbol: "STMXBTC",
+    baseAsset: "STMX",
+    quoteAsset: "BTC",
+  },
+  STMXETH: {
+    symbol: "STMXETH",
+    baseAsset: "STMX",
+    quoteAsset: "ETH",
+  },
+  STMXUSDT: {
+    symbol: "STMXUSDT",
+    baseAsset: "STMX",
+    quoteAsset: "USDT",
+  },
+  KNCBUSD: {
+    symbol: "KNCBUSD",
+    baseAsset: "KNC",
+    quoteAsset: "BUSD",
+  },
+  KNCUSDT: {
+    symbol: "KNCUSDT",
+    baseAsset: "KNC",
+    quoteAsset: "USDT",
+  },
+  REPBUSD: {
+    symbol: "REPBUSD",
+    baseAsset: "REP",
+    quoteAsset: "BUSD",
+  },
+  REPUSDT: {
+    symbol: "REPUSDT",
+    baseAsset: "REP",
+    quoteAsset: "USDT",
+  },
+  LRCBUSD: {
+    symbol: "LRCBUSD",
+    baseAsset: "LRC",
+    quoteAsset: "BUSD",
+  },
+  LRCUSDT: {
+    symbol: "LRCUSDT",
+    baseAsset: "LRC",
+    quoteAsset: "USDT",
+  },
+  IQBNB: {
+    symbol: "IQBNB",
+    baseAsset: "IQ",
+    quoteAsset: "BNB",
+  },
+  IQBUSD: {
+    symbol: "IQBUSD",
+    baseAsset: "IQ",
+    quoteAsset: "BUSD",
+  },
+  PNTBTC: {
+    symbol: "PNTBTC",
+    baseAsset: "PNT",
+    quoteAsset: "BTC",
+  },
+  PNTUSDT: {
+    symbol: "PNTUSDT",
+    baseAsset: "PNT",
+    quoteAsset: "USDT",
+  },
+  BTCGBP: {
+    symbol: "BTCGBP",
+    baseAsset: "BTC",
+    quoteAsset: "GBP",
+  },
+  ETHGBP: {
+    symbol: "ETHGBP",
+    baseAsset: "ETH",
+    quoteAsset: "GBP",
+  },
+  XRPGBP: {
+    symbol: "XRPGBP",
+    baseAsset: "XRP",
+    quoteAsset: "GBP",
+  },
+  BNBGBP: {
+    symbol: "BNBGBP",
+    baseAsset: "BNB",
+    quoteAsset: "GBP",
+  },
+  GBPBUSD: {
+    symbol: "GBPBUSD",
+    baseAsset: "GBP",
+    quoteAsset: "BUSD",
+  },
+  DGBBNB: {
+    symbol: "DGBBNB",
+    baseAsset: "DGB",
+    quoteAsset: "BNB",
+  },
+  DGBBTC: {
+    symbol: "DGBBTC",
+    baseAsset: "DGB",
+    quoteAsset: "BTC",
+  },
+  DGBBUSD: {
+    symbol: "DGBBUSD",
+    baseAsset: "DGB",
+    quoteAsset: "BUSD",
+  },
+  BTCUAH: {
+    symbol: "BTCUAH",
+    baseAsset: "BTC",
+    quoteAsset: "UAH",
+  },
+  USDTUAH: {
+    symbol: "USDTUAH",
+    baseAsset: "USDT",
+    quoteAsset: "UAH",
+  },
+  COMPBTC: {
+    symbol: "COMPBTC",
+    baseAsset: "COMP",
+    quoteAsset: "BTC",
+  },
+  COMPBNB: {
+    symbol: "COMPBNB",
+    baseAsset: "COMP",
+    quoteAsset: "BNB",
+  },
+  COMPBUSD: {
+    symbol: "COMPBUSD",
+    baseAsset: "COMP",
+    quoteAsset: "BUSD",
+  },
+  COMPUSDT: {
+    symbol: "COMPUSDT",
+    baseAsset: "COMP",
+    quoteAsset: "USDT",
+  },
+  BTCBIDR: {
+    symbol: "BTCBIDR",
+    baseAsset: "BTC",
+    quoteAsset: "BIDR",
+  },
+  ETHBIDR: {
+    symbol: "ETHBIDR",
+    baseAsset: "ETH",
+    quoteAsset: "BIDR",
+  },
+  BNBBIDR: {
+    symbol: "BNBBIDR",
+    baseAsset: "BNB",
+    quoteAsset: "BIDR",
+  },
+  BUSDBIDR: {
+    symbol: "BUSDBIDR",
+    baseAsset: "BUSD",
+    quoteAsset: "BIDR",
+  },
+  USDTBIDR: {
+    symbol: "USDTBIDR",
+    baseAsset: "USDT",
+    quoteAsset: "BIDR",
+  },
+  BKRWUSDT: {
+    symbol: "BKRWUSDT",
+    baseAsset: "BKRW",
+    quoteAsset: "USDT",
+  },
+  BKRWBUSD: {
+    symbol: "BKRWBUSD",
+    baseAsset: "BKRW",
+    quoteAsset: "BUSD",
+  },
+  SCUSDT: {
+    symbol: "SCUSDT",
+    baseAsset: "SC",
+    quoteAsset: "USDT",
+  },
+  ZENUSDT: {
+    symbol: "ZENUSDT",
+    baseAsset: "ZEN",
+    quoteAsset: "USDT",
+  },
+  SXPBTC: {
+    symbol: "SXPBTC",
+    baseAsset: "SXP",
+    quoteAsset: "BTC",
+  },
+  SXPBNB: {
+    symbol: "SXPBNB",
+    baseAsset: "SXP",
+    quoteAsset: "BNB",
+  },
+  SXPBUSD: {
+    symbol: "SXPBUSD",
+    baseAsset: "SXP",
+    quoteAsset: "BUSD",
+  },
+  SNXBTC: {
+    symbol: "SNXBTC",
+    baseAsset: "SNX",
+    quoteAsset: "BTC",
+  },
+  SNXBNB: {
+    symbol: "SNXBNB",
+    baseAsset: "SNX",
+    quoteAsset: "BNB",
+  },
+  SNXBUSD: {
+    symbol: "SNXBUSD",
+    baseAsset: "SNX",
+    quoteAsset: "BUSD",
+  },
+  SNXUSDT: {
+    symbol: "SNXUSDT",
+    baseAsset: "SNX",
+    quoteAsset: "USDT",
+  },
+  ETHUPUSDT: {
+    symbol: "ETHUPUSDT",
+    baseAsset: "ETHUP",
+    quoteAsset: "USDT",
+  },
+  ETHDOWNUSDT: {
+    symbol: "ETHDOWNUSDT",
+    baseAsset: "ETHDOWN",
+    quoteAsset: "USDT",
+  },
+  ADAUPUSDT: {
+    symbol: "ADAUPUSDT",
+    baseAsset: "ADAUP",
+    quoteAsset: "USDT",
+  },
+  ADADOWNUSDT: {
+    symbol: "ADADOWNUSDT",
+    baseAsset: "ADADOWN",
+    quoteAsset: "USDT",
+  },
+  LINKUPUSDT: {
+    symbol: "LINKUPUSDT",
+    baseAsset: "LINKUP",
+    quoteAsset: "USDT",
+  },
+  LINKDOWNUSDT: {
+    symbol: "LINKDOWNUSDT",
+    baseAsset: "LINKDOWN",
+    quoteAsset: "USDT",
+  },
+  VTHOBNB: {
+    symbol: "VTHOBNB",
+    baseAsset: "VTHO",
+    quoteAsset: "BNB",
+  },
+  VTHOBUSD: {
+    symbol: "VTHOBUSD",
+    baseAsset: "VTHO",
+    quoteAsset: "BUSD",
+  },
+  VTHOUSDT: {
+    symbol: "VTHOUSDT",
+    baseAsset: "VTHO",
+    quoteAsset: "USDT",
+  },
+  DCRBUSD: {
+    symbol: "DCRBUSD",
+    baseAsset: "DCR",
+    quoteAsset: "BUSD",
+  },
+  DGBUSDT: {
+    symbol: "DGBUSDT",
+    baseAsset: "DGB",
+    quoteAsset: "USDT",
+  },
+  GBPUSDT: {
+    symbol: "GBPUSDT",
+    baseAsset: "GBP",
+    quoteAsset: "USDT",
+  },
+  STORJBUSD: {
+    symbol: "STORJBUSD",
+    baseAsset: "STORJ",
+    quoteAsset: "BUSD",
+  },
+  SXPUSDT: {
+    symbol: "SXPUSDT",
+    baseAsset: "SXP",
+    quoteAsset: "USDT",
+  },
+  IRISBNB: {
+    symbol: "IRISBNB",
+    baseAsset: "IRIS",
+    quoteAsset: "BNB",
+  },
+  IRISBTC: {
+    symbol: "IRISBTC",
+    baseAsset: "IRIS",
+    quoteAsset: "BTC",
+  },
+  IRISBUSD: {
+    symbol: "IRISBUSD",
+    baseAsset: "IRIS",
+    quoteAsset: "BUSD",
+  },
+  MKRBNB: {
+    symbol: "MKRBNB",
+    baseAsset: "MKR",
+    quoteAsset: "BNB",
+  },
+  MKRBTC: {
+    symbol: "MKRBTC",
+    baseAsset: "MKR",
+    quoteAsset: "BTC",
+  },
+  MKRUSDT: {
+    symbol: "MKRUSDT",
+    baseAsset: "MKR",
+    quoteAsset: "USDT",
+  },
+  MKRBUSD: {
+    symbol: "MKRBUSD",
+    baseAsset: "MKR",
+    quoteAsset: "BUSD",
+  },
+  DAIBNB: {
+    symbol: "DAIBNB",
+    baseAsset: "DAI",
+    quoteAsset: "BNB",
+  },
+  DAIBTC: {
+    symbol: "DAIBTC",
+    baseAsset: "DAI",
+    quoteAsset: "BTC",
+  },
+  DAIUSDT: {
+    symbol: "DAIUSDT",
+    baseAsset: "DAI",
+    quoteAsset: "USDT",
+  },
+  DAIBUSD: {
+    symbol: "DAIBUSD",
+    baseAsset: "DAI",
+    quoteAsset: "BUSD",
+  },
+  RUNEBNB: {
+    symbol: "RUNEBNB",
+    baseAsset: "RUNE",
+    quoteAsset: "BNB",
+  },
+  RUNEBTC: {
+    symbol: "RUNEBTC",
+    baseAsset: "RUNE",
+    quoteAsset: "BTC",
+  },
+  RUNEBUSD: {
+    symbol: "RUNEBUSD",
+    baseAsset: "RUNE",
+    quoteAsset: "BUSD",
+  },
+  MANABUSD: {
+    symbol: "MANABUSD",
+    baseAsset: "MANA",
+    quoteAsset: "BUSD",
+  },
+  DOGEBUSD: {
+    symbol: "DOGEBUSD",
+    baseAsset: "DOGE",
+    quoteAsset: "BUSD",
+  },
+  LENDBUSD: {
+    symbol: "LENDBUSD",
+    baseAsset: "LEND",
+    quoteAsset: "BUSD",
+  },
+  ZRXBUSD: {
+    symbol: "ZRXBUSD",
+    baseAsset: "ZRX",
+    quoteAsset: "BUSD",
+  },
+  DCRUSDT: {
+    symbol: "DCRUSDT",
+    baseAsset: "DCR",
+    quoteAsset: "USDT",
+  },
+  STORJUSDT: {
+    symbol: "STORJUSDT",
+    baseAsset: "STORJ",
+    quoteAsset: "USDT",
+  },
+  XRPBKRW: {
+    symbol: "XRPBKRW",
+    baseAsset: "XRP",
+    quoteAsset: "BKRW",
+  },
+  ADABKRW: {
+    symbol: "ADABKRW",
+    baseAsset: "ADA",
+    quoteAsset: "BKRW",
+  },
+  BTCAUD: {
+    symbol: "BTCAUD",
+    baseAsset: "BTC",
+    quoteAsset: "AUD",
+  },
+  ETHAUD: {
+    symbol: "ETHAUD",
+    baseAsset: "ETH",
+    quoteAsset: "AUD",
+  },
+  AUDBUSD: {
+    symbol: "AUDBUSD",
+    baseAsset: "AUD",
+    quoteAsset: "BUSD",
+  },
+  FIOBNB: {
+    symbol: "FIOBNB",
+    baseAsset: "FIO",
+    quoteAsset: "BNB",
+  },
+  FIOBTC: {
+    symbol: "FIOBTC",
+    baseAsset: "FIO",
+    quoteAsset: "BTC",
+  },
+  FIOBUSD: {
+    symbol: "FIOBUSD",
+    baseAsset: "FIO",
+    quoteAsset: "BUSD",
+  },
+  BNBUPUSDT: {
+    symbol: "BNBUPUSDT",
+    baseAsset: "BNBUP",
+    quoteAsset: "USDT",
+  },
+  BNBDOWNUSDT: {
+    symbol: "BNBDOWNUSDT",
+    baseAsset: "BNBDOWN",
+    quoteAsset: "USDT",
+  },
+  XTZUPUSDT: {
+    symbol: "XTZUPUSDT",
+    baseAsset: "XTZUP",
+    quoteAsset: "USDT",
+  },
+  XTZDOWNUSDT: {
+    symbol: "XTZDOWNUSDT",
+    baseAsset: "XTZDOWN",
+    quoteAsset: "USDT",
+  },
+  AVABNB: {
+    symbol: "AVABNB",
+    baseAsset: "AVA",
+    quoteAsset: "BNB",
+  },
+  AVABTC: {
+    symbol: "AVABTC",
+    baseAsset: "AVA",
+    quoteAsset: "BTC",
+  },
+  AVABUSD: {
+    symbol: "AVABUSD",
+    baseAsset: "AVA",
+    quoteAsset: "BUSD",
+  },
+  USDTBKRW: {
+    symbol: "USDTBKRW",
+    baseAsset: "USDT",
+    quoteAsset: "BKRW",
+  },
+  BUSDBKRW: {
+    symbol: "BUSDBKRW",
+    baseAsset: "BUSD",
+    quoteAsset: "BKRW",
+  },
+  IOTABUSD: {
+    symbol: "IOTABUSD",
+    baseAsset: "IOTA",
+    quoteAsset: "BUSD",
+  },
+  MANAUSDT: {
+    symbol: "MANAUSDT",
+    baseAsset: "MANA",
+    quoteAsset: "USDT",
+  },
+  XRPAUD: {
+    symbol: "XRPAUD",
+    baseAsset: "XRP",
+    quoteAsset: "AUD",
+  },
+  BNBAUD: {
+    symbol: "BNBAUD",
+    baseAsset: "BNB",
+    quoteAsset: "AUD",
+  },
+  AUDUSDT: {
+    symbol: "AUDUSDT",
+    baseAsset: "AUD",
+    quoteAsset: "USDT",
+  },
+  BALBNB: {
+    symbol: "BALBNB",
+    baseAsset: "BAL",
+    quoteAsset: "BNB",
+  },
+  BALBTC: {
+    symbol: "BALBTC",
+    baseAsset: "BAL",
+    quoteAsset: "BTC",
+  },
+  BALBUSD: {
+    symbol: "BALBUSD",
+    baseAsset: "BAL",
+    quoteAsset: "BUSD",
+  },
+  YFIBNB: {
+    symbol: "YFIBNB",
+    baseAsset: "YFI",
+    quoteAsset: "BNB",
+  },
+  YFIBTC: {
+    symbol: "YFIBTC",
+    baseAsset: "YFI",
+    quoteAsset: "BTC",
+  },
+  YFIBUSD: {
+    symbol: "YFIBUSD",
+    baseAsset: "YFI",
+    quoteAsset: "BUSD",
+  },
+  YFIUSDT: {
+    symbol: "YFIUSDT",
+    baseAsset: "YFI",
+    quoteAsset: "USDT",
+  },
+  BLZBUSD: {
+    symbol: "BLZBUSD",
+    baseAsset: "BLZ",
+    quoteAsset: "BUSD",
+  },
+  KMDBUSD: {
+    symbol: "KMDBUSD",
+    baseAsset: "KMD",
+    quoteAsset: "BUSD",
+  },
+  BALUSDT: {
+    symbol: "BALUSDT",
+    baseAsset: "BAL",
+    quoteAsset: "USDT",
+  },
+  BLZUSDT: {
+    symbol: "BLZUSDT",
+    baseAsset: "BLZ",
+    quoteAsset: "USDT",
+  },
+  IRISUSDT: {
+    symbol: "IRISUSDT",
+    baseAsset: "IRIS",
+    quoteAsset: "USDT",
+  },
+  KMDUSDT: {
+    symbol: "KMDUSDT",
+    baseAsset: "KMD",
+    quoteAsset: "USDT",
+  },
+  BTCDAI: {
+    symbol: "BTCDAI",
+    baseAsset: "BTC",
+    quoteAsset: "DAI",
+  },
+  ETHDAI: {
+    symbol: "ETHDAI",
+    baseAsset: "ETH",
+    quoteAsset: "DAI",
+  },
+  BNBDAI: {
+    symbol: "BNBDAI",
+    baseAsset: "BNB",
+    quoteAsset: "DAI",
+  },
+  USDTDAI: {
+    symbol: "USDTDAI",
+    baseAsset: "USDT",
+    quoteAsset: "DAI",
+  },
+  BUSDDAI: {
+    symbol: "BUSDDAI",
+    baseAsset: "BUSD",
+    quoteAsset: "DAI",
+  },
+  JSTBNB: {
+    symbol: "JSTBNB",
+    baseAsset: "JST",
+    quoteAsset: "BNB",
+  },
+  JSTBTC: {
+    symbol: "JSTBTC",
+    baseAsset: "JST",
+    quoteAsset: "BTC",
+  },
+  JSTBUSD: {
+    symbol: "JSTBUSD",
+    baseAsset: "JST",
+    quoteAsset: "BUSD",
+  },
+  JSTUSDT: {
+    symbol: "JSTUSDT",
+    baseAsset: "JST",
+    quoteAsset: "USDT",
+  },
+  SRMBNB: {
+    symbol: "SRMBNB",
+    baseAsset: "SRM",
+    quoteAsset: "BNB",
+  },
+  SRMBTC: {
+    symbol: "SRMBTC",
+    baseAsset: "SRM",
+    quoteAsset: "BTC",
+  },
+  SRMBUSD: {
+    symbol: "SRMBUSD",
+    baseAsset: "SRM",
+    quoteAsset: "BUSD",
+  },
+  SRMUSDT: {
+    symbol: "SRMUSDT",
+    baseAsset: "SRM",
+    quoteAsset: "USDT",
+  },
+  ANTBNB: {
+    symbol: "ANTBNB",
+    baseAsset: "ANT",
+    quoteAsset: "BNB",
+  },
+  ANTBTC: {
+    symbol: "ANTBTC",
+    baseAsset: "ANT",
+    quoteAsset: "BTC",
+  },
+  ANTBUSD: {
+    symbol: "ANTBUSD",
+    baseAsset: "ANT",
+    quoteAsset: "BUSD",
+  },
+  ANTUSDT: {
+    symbol: "ANTUSDT",
+    baseAsset: "ANT",
+    quoteAsset: "USDT",
+  },
+  CRVBNB: {
+    symbol: "CRVBNB",
+    baseAsset: "CRV",
+    quoteAsset: "BNB",
+  },
+  CRVBTC: {
+    symbol: "CRVBTC",
+    baseAsset: "CRV",
+    quoteAsset: "BTC",
+  },
+  CRVBUSD: {
+    symbol: "CRVBUSD",
+    baseAsset: "CRV",
+    quoteAsset: "BUSD",
+  },
+  CRVUSDT: {
+    symbol: "CRVUSDT",
+    baseAsset: "CRV",
+    quoteAsset: "USDT",
+  },
+  SANDBNB: {
+    symbol: "SANDBNB",
+    baseAsset: "SAND",
+    quoteAsset: "BNB",
+  },
+  SANDBTC: {
+    symbol: "SANDBTC",
+    baseAsset: "SAND",
+    quoteAsset: "BTC",
+  },
+  SANDUSDT: {
+    symbol: "SANDUSDT",
+    baseAsset: "SAND",
+    quoteAsset: "USDT",
+  },
+  SANDBUSD: {
+    symbol: "SANDBUSD",
+    baseAsset: "SAND",
+    quoteAsset: "BUSD",
+  },
+  OCEANBNB: {
+    symbol: "OCEANBNB",
+    baseAsset: "OCEAN",
+    quoteAsset: "BNB",
+  },
+  OCEANBTC: {
+    symbol: "OCEANBTC",
+    baseAsset: "OCEAN",
+    quoteAsset: "BTC",
+  },
+  OCEANBUSD: {
+    symbol: "OCEANBUSD",
+    baseAsset: "OCEAN",
+    quoteAsset: "BUSD",
+  },
+  OCEANUSDT: {
+    symbol: "OCEANUSDT",
+    baseAsset: "OCEAN",
+    quoteAsset: "USDT",
+  },
+  NMRBNB: {
+    symbol: "NMRBNB",
+    baseAsset: "NMR",
+    quoteAsset: "BNB",
+  },
+  NMRBTC: {
+    symbol: "NMRBTC",
+    baseAsset: "NMR",
+    quoteAsset: "BTC",
+  },
+  NMRBUSD: {
+    symbol: "NMRBUSD",
+    baseAsset: "NMR",
+    quoteAsset: "BUSD",
+  },
+  NMRUSDT: {
+    symbol: "NMRUSDT",
+    baseAsset: "NMR",
+    quoteAsset: "USDT",
+  },
+  DOTBNB: {
+    symbol: "DOTBNB",
+    baseAsset: "DOT",
+    quoteAsset: "BNB",
+  },
+  DOTBTC: {
+    symbol: "DOTBTC",
+    baseAsset: "DOT",
+    quoteAsset: "BTC",
+  },
+  DOTBUSD: {
+    symbol: "DOTBUSD",
+    baseAsset: "DOT",
+    quoteAsset: "BUSD",
+  },
+  DOTUSDT: {
+    symbol: "DOTUSDT",
+    baseAsset: "DOT",
+    quoteAsset: "USDT",
+  },
+  LUNABNB: {
+    symbol: "LUNABNB",
+    baseAsset: "LUNA",
+    quoteAsset: "BNB",
+  },
+  LUNABTC: {
+    symbol: "LUNABTC",
+    baseAsset: "LUNA",
+    quoteAsset: "BTC",
+  },
+  LUNABUSD: {
+    symbol: "LUNABUSD",
+    baseAsset: "LUNA",
+    quoteAsset: "BUSD",
+  },
+  LUNAUSDT: {
+    symbol: "LUNAUSDT",
+    baseAsset: "LUNA",
+    quoteAsset: "USDT",
+  },
+  IDEXBTC: {
+    symbol: "IDEXBTC",
+    baseAsset: "IDEX",
+    quoteAsset: "BTC",
+  },
+  IDEXBUSD: {
+    symbol: "IDEXBUSD",
+    baseAsset: "IDEX",
+    quoteAsset: "BUSD",
+  },
+  RSRBNB: {
+    symbol: "RSRBNB",
+    baseAsset: "RSR",
+    quoteAsset: "BNB",
+  },
+  RSRBTC: {
+    symbol: "RSRBTC",
+    baseAsset: "RSR",
+    quoteAsset: "BTC",
+  },
+  RSRBUSD: {
+    symbol: "RSRBUSD",
+    baseAsset: "RSR",
+    quoteAsset: "BUSD",
+  },
+  RSRUSDT: {
+    symbol: "RSRUSDT",
+    baseAsset: "RSR",
+    quoteAsset: "USDT",
+  },
+  PAXGBNB: {
+    symbol: "PAXGBNB",
+    baseAsset: "PAXG",
+    quoteAsset: "BNB",
+  },
+  PAXGBTC: {
+    symbol: "PAXGBTC",
+    baseAsset: "PAXG",
+    quoteAsset: "BTC",
+  },
+  PAXGBUSD: {
+    symbol: "PAXGBUSD",
+    baseAsset: "PAXG",
+    quoteAsset: "BUSD",
+  },
+  PAXGUSDT: {
+    symbol: "PAXGUSDT",
+    baseAsset: "PAXG",
+    quoteAsset: "USDT",
+  },
+  WNXMBNB: {
+    symbol: "WNXMBNB",
+    baseAsset: "WNXM",
+    quoteAsset: "BNB",
+  },
+  WNXMBTC: {
+    symbol: "WNXMBTC",
+    baseAsset: "WNXM",
+    quoteAsset: "BTC",
+  },
+  WNXMBUSD: {
+    symbol: "WNXMBUSD",
+    baseAsset: "WNXM",
+    quoteAsset: "BUSD",
+  },
+  WNXMUSDT: {
+    symbol: "WNXMUSDT",
+    baseAsset: "WNXM",
+    quoteAsset: "USDT",
+  },
+  TRBBNB: {
+    symbol: "TRBBNB",
+    baseAsset: "TRB",
+    quoteAsset: "BNB",
+  },
+  TRBBTC: {
+    symbol: "TRBBTC",
+    baseAsset: "TRB",
+    quoteAsset: "BTC",
+  },
+  TRBBUSD: {
+    symbol: "TRBBUSD",
+    baseAsset: "TRB",
+    quoteAsset: "BUSD",
+  },
+  TRBUSDT: {
+    symbol: "TRBUSDT",
+    baseAsset: "TRB",
+    quoteAsset: "USDT",
+  },
+  ETHNGN: {
+    symbol: "ETHNGN",
+    baseAsset: "ETH",
+    quoteAsset: "NGN",
+  },
+  DOTBIDR: {
+    symbol: "DOTBIDR",
+    baseAsset: "DOT",
+    quoteAsset: "BIDR",
+  },
+  LINKAUD: {
+    symbol: "LINKAUD",
+    baseAsset: "LINK",
+    quoteAsset: "AUD",
+  },
+  SXPAUD: {
+    symbol: "SXPAUD",
+    baseAsset: "SXP",
+    quoteAsset: "AUD",
+  },
+  BZRXBNB: {
+    symbol: "BZRXBNB",
+    baseAsset: "BZRX",
+    quoteAsset: "BNB",
+  },
+  BZRXBTC: {
+    symbol: "BZRXBTC",
+    baseAsset: "BZRX",
+    quoteAsset: "BTC",
+  },
+  BZRXBUSD: {
+    symbol: "BZRXBUSD",
+    baseAsset: "BZRX",
+    quoteAsset: "BUSD",
+  },
+  BZRXUSDT: {
+    symbol: "BZRXUSDT",
+    baseAsset: "BZRX",
+    quoteAsset: "USDT",
+  },
+  WBTCBTC: {
+    symbol: "WBTCBTC",
+    baseAsset: "WBTC",
+    quoteAsset: "BTC",
+  },
+  WBTCETH: {
+    symbol: "WBTCETH",
+    baseAsset: "WBTC",
+    quoteAsset: "ETH",
+  },
+  SUSHIBNB: {
+    symbol: "SUSHIBNB",
+    baseAsset: "SUSHI",
+    quoteAsset: "BNB",
+  },
+  SUSHIBTC: {
+    symbol: "SUSHIBTC",
+    baseAsset: "SUSHI",
+    quoteAsset: "BTC",
+  },
+  SUSHIBUSD: {
+    symbol: "SUSHIBUSD",
+    baseAsset: "SUSHI",
+    quoteAsset: "BUSD",
+  },
+  SUSHIUSDT: {
+    symbol: "SUSHIUSDT",
+    baseAsset: "SUSHI",
+    quoteAsset: "USDT",
+  },
+  YFIIBNB: {
+    symbol: "YFIIBNB",
+    baseAsset: "YFII",
+    quoteAsset: "BNB",
+  },
+  YFIIBTC: {
+    symbol: "YFIIBTC",
+    baseAsset: "YFII",
+    quoteAsset: "BTC",
+  },
+  YFIIBUSD: {
+    symbol: "YFIIBUSD",
+    baseAsset: "YFII",
+    quoteAsset: "BUSD",
+  },
+  YFIIUSDT: {
+    symbol: "YFIIUSDT",
+    baseAsset: "YFII",
+    quoteAsset: "USDT",
+  },
+  KSMBNB: {
+    symbol: "KSMBNB",
+    baseAsset: "KSM",
+    quoteAsset: "BNB",
+  },
+  KSMBTC: {
+    symbol: "KSMBTC",
+    baseAsset: "KSM",
+    quoteAsset: "BTC",
+  },
+  KSMBUSD: {
+    symbol: "KSMBUSD",
+    baseAsset: "KSM",
+    quoteAsset: "BUSD",
+  },
+  KSMUSDT: {
+    symbol: "KSMUSDT",
+    baseAsset: "KSM",
+    quoteAsset: "USDT",
+  },
+  EGLDBNB: {
+    symbol: "EGLDBNB",
+    baseAsset: "EGLD",
+    quoteAsset: "BNB",
+  },
+  EGLDBTC: {
+    symbol: "EGLDBTC",
+    baseAsset: "EGLD",
+    quoteAsset: "BTC",
+  },
+  EGLDBUSD: {
+    symbol: "EGLDBUSD",
+    baseAsset: "EGLD",
+    quoteAsset: "BUSD",
+  },
+  EGLDUSDT: {
+    symbol: "EGLDUSDT",
+    baseAsset: "EGLD",
+    quoteAsset: "USDT",
+  },
+  DIABNB: {
+    symbol: "DIABNB",
+    baseAsset: "DIA",
+    quoteAsset: "BNB",
+  },
+  DIABTC: {
+    symbol: "DIABTC",
+    baseAsset: "DIA",
+    quoteAsset: "BTC",
+  },
+  DIABUSD: {
+    symbol: "DIABUSD",
+    baseAsset: "DIA",
+    quoteAsset: "BUSD",
+  },
+  DIAUSDT: {
+    symbol: "DIAUSDT",
+    baseAsset: "DIA",
+    quoteAsset: "USDT",
+  },
+  RUNEUSDT: {
+    symbol: "RUNEUSDT",
+    baseAsset: "RUNE",
+    quoteAsset: "USDT",
+  },
+  FIOUSDT: {
+    symbol: "FIOUSDT",
+    baseAsset: "FIO",
+    quoteAsset: "USDT",
+  },
+  UMABTC: {
+    symbol: "UMABTC",
+    baseAsset: "UMA",
+    quoteAsset: "BTC",
+  },
+  UMAUSDT: {
+    symbol: "UMAUSDT",
+    baseAsset: "UMA",
+    quoteAsset: "USDT",
+  },
+  EOSUPUSDT: {
+    symbol: "EOSUPUSDT",
+    baseAsset: "EOSUP",
+    quoteAsset: "USDT",
+  },
+  EOSDOWNUSDT: {
+    symbol: "EOSDOWNUSDT",
+    baseAsset: "EOSDOWN",
+    quoteAsset: "USDT",
+  },
+  TRXUPUSDT: {
+    symbol: "TRXUPUSDT",
+    baseAsset: "TRXUP",
+    quoteAsset: "USDT",
+  },
+  TRXDOWNUSDT: {
+    symbol: "TRXDOWNUSDT",
+    baseAsset: "TRXDOWN",
+    quoteAsset: "USDT",
+  },
+  XRPUPUSDT: {
+    symbol: "XRPUPUSDT",
+    baseAsset: "XRPUP",
+    quoteAsset: "USDT",
+  },
+  XRPDOWNUSDT: {
+    symbol: "XRPDOWNUSDT",
+    baseAsset: "XRPDOWN",
+    quoteAsset: "USDT",
+  },
+  DOTUPUSDT: {
+    symbol: "DOTUPUSDT",
+    baseAsset: "DOTUP",
+    quoteAsset: "USDT",
+  },
+  DOTDOWNUSDT: {
+    symbol: "DOTDOWNUSDT",
+    baseAsset: "DOTDOWN",
+    quoteAsset: "USDT",
+  },
+  SRMBIDR: {
+    symbol: "SRMBIDR",
+    baseAsset: "SRM",
+    quoteAsset: "BIDR",
+  },
+  ONEBIDR: {
+    symbol: "ONEBIDR",
+    baseAsset: "ONE",
+    quoteAsset: "BIDR",
+  },
+  LINKTRY: {
+    symbol: "LINKTRY",
+    baseAsset: "LINK",
+    quoteAsset: "TRY",
+  },
+  USDTNGN: {
+    symbol: "USDTNGN",
+    baseAsset: "USDT",
+    quoteAsset: "NGN",
+  },
+  BELBNB: {
+    symbol: "BELBNB",
+    baseAsset: "BEL",
+    quoteAsset: "BNB",
+  },
+  BELBTC: {
+    symbol: "BELBTC",
+    baseAsset: "BEL",
+    quoteAsset: "BTC",
+  },
+  BELBUSD: {
+    symbol: "BELBUSD",
+    baseAsset: "BEL",
+    quoteAsset: "BUSD",
+  },
+  BELUSDT: {
+    symbol: "BELUSDT",
+    baseAsset: "BEL",
+    quoteAsset: "USDT",
+  },
+  WINGBNB: {
+    symbol: "WINGBNB",
+    baseAsset: "WING",
+    quoteAsset: "BNB",
+  },
+  WINGBTC: {
+    symbol: "WINGBTC",
+    baseAsset: "WING",
+    quoteAsset: "BTC",
+  },
+  SWRVBNB: {
+    symbol: "SWRVBNB",
+    baseAsset: "SWRV",
+    quoteAsset: "BNB",
+  },
+  SWRVBUSD: {
+    symbol: "SWRVBUSD",
+    baseAsset: "SWRV",
+    quoteAsset: "BUSD",
+  },
+  WINGBUSD: {
+    symbol: "WINGBUSD",
+    baseAsset: "WING",
+    quoteAsset: "BUSD",
+  },
+  WINGUSDT: {
+    symbol: "WINGUSDT",
+    baseAsset: "WING",
+    quoteAsset: "USDT",
+  },
+  LTCUPUSDT: {
+    symbol: "LTCUPUSDT",
+    baseAsset: "LTCUP",
+    quoteAsset: "USDT",
+  },
+  LTCDOWNUSDT: {
+    symbol: "LTCDOWNUSDT",
+    baseAsset: "LTCDOWN",
+    quoteAsset: "USDT",
+  },
+  LENDBKRW: {
+    symbol: "LENDBKRW",
+    baseAsset: "LEND",
+    quoteAsset: "BKRW",
+  },
+  SXPEUR: {
+    symbol: "SXPEUR",
+    baseAsset: "SXP",
+    quoteAsset: "EUR",
+  },
+  CREAMBNB: {
+    symbol: "CREAMBNB",
+    baseAsset: "CREAM",
+    quoteAsset: "BNB",
+  },
+  CREAMBUSD: {
+    symbol: "CREAMBUSD",
+    baseAsset: "CREAM",
+    quoteAsset: "BUSD",
+  },
+  UNIBNB: {
+    symbol: "UNIBNB",
+    baseAsset: "UNI",
+    quoteAsset: "BNB",
+  },
+  UNIBTC: {
+    symbol: "UNIBTC",
+    baseAsset: "UNI",
+    quoteAsset: "BTC",
+  },
+  UNIBUSD: {
+    symbol: "UNIBUSD",
+    baseAsset: "UNI",
+    quoteAsset: "BUSD",
+  },
+  UNIUSDT: {
+    symbol: "UNIUSDT",
+    baseAsset: "UNI",
+    quoteAsset: "USDT",
+  },
+  NBSBTC: {
+    symbol: "NBSBTC",
+    baseAsset: "NBS",
+    quoteAsset: "BTC",
+  },
+  NBSUSDT: {
+    symbol: "NBSUSDT",
+    baseAsset: "NBS",
+    quoteAsset: "USDT",
+  },
+  OXTBTC: {
+    symbol: "OXTBTC",
+    baseAsset: "OXT",
+    quoteAsset: "BTC",
+  },
+  OXTUSDT: {
+    symbol: "OXTUSDT",
+    baseAsset: "OXT",
+    quoteAsset: "USDT",
+  },
+  SUNBTC: {
+    symbol: "SUNBTC",
+    baseAsset: "SUN",
+    quoteAsset: "BTC",
+  },
+  SUNUSDT: {
+    symbol: "SUNUSDT",
+    baseAsset: "SUN",
+    quoteAsset: "USDT",
+  },
+  AVAXBNB: {
+    symbol: "AVAXBNB",
+    baseAsset: "AVAX",
+    quoteAsset: "BNB",
+  },
+  AVAXBTC: {
+    symbol: "AVAXBTC",
+    baseAsset: "AVAX",
+    quoteAsset: "BTC",
+  },
+  AVAXBUSD: {
+    symbol: "AVAXBUSD",
+    baseAsset: "AVAX",
+    quoteAsset: "BUSD",
+  },
+  AVAXUSDT: {
+    symbol: "AVAXUSDT",
+    baseAsset: "AVAX",
+    quoteAsset: "USDT",
+  },
+  HNTBTC: {
+    symbol: "HNTBTC",
+    baseAsset: "HNT",
+    quoteAsset: "BTC",
+  },
+  HNTUSDT: {
+    symbol: "HNTUSDT",
+    baseAsset: "HNT",
+    quoteAsset: "USDT",
+  },
+  BAKEBNB: {
+    symbol: "BAKEBNB",
+    baseAsset: "BAKE",
+    quoteAsset: "BNB",
+  },
+  BURGERBNB: {
+    symbol: "BURGERBNB",
+    baseAsset: "BURGER",
+    quoteAsset: "BNB",
+  },
+  SXPBIDR: {
+    symbol: "SXPBIDR",
+    baseAsset: "SXP",
+    quoteAsset: "BIDR",
+  },
+  LINKBKRW: {
+    symbol: "LINKBKRW",
+    baseAsset: "LINK",
+    quoteAsset: "BKRW",
+  },
+  FLMBNB: {
+    symbol: "FLMBNB",
+    baseAsset: "FLM",
+    quoteAsset: "BNB",
+  },
+  FLMBTC: {
+    symbol: "FLMBTC",
+    baseAsset: "FLM",
+    quoteAsset: "BTC",
+  },
+  FLMBUSD: {
+    symbol: "FLMBUSD",
+    baseAsset: "FLM",
+    quoteAsset: "BUSD",
+  },
+  FLMUSDT: {
+    symbol: "FLMUSDT",
+    baseAsset: "FLM",
+    quoteAsset: "USDT",
+  },
+  SCRTBTC: {
+    symbol: "SCRTBTC",
+    baseAsset: "SCRT",
+    quoteAsset: "BTC",
+  },
+  SCRTETH: {
+    symbol: "SCRTETH",
+    baseAsset: "SCRT",
+    quoteAsset: "ETH",
+  },
+  CAKEBNB: {
+    symbol: "CAKEBNB",
+    baseAsset: "CAKE",
+    quoteAsset: "BNB",
+  },
+  CAKEBUSD: {
+    symbol: "CAKEBUSD",
+    baseAsset: "CAKE",
+    quoteAsset: "BUSD",
+  },
+  SPARTABNB: {
+    symbol: "SPARTABNB",
+    baseAsset: "SPARTA",
+    quoteAsset: "BNB",
+  },
+  UNIUPUSDT: {
+    symbol: "UNIUPUSDT",
+    baseAsset: "UNIUP",
+    quoteAsset: "USDT",
+  },
+  UNIDOWNUSDT: {
+    symbol: "UNIDOWNUSDT",
+    baseAsset: "UNIDOWN",
+    quoteAsset: "USDT",
+  },
+  ORNBTC: {
+    symbol: "ORNBTC",
+    baseAsset: "ORN",
+    quoteAsset: "BTC",
+  },
+  ORNUSDT: {
+    symbol: "ORNUSDT",
+    baseAsset: "ORN",
+    quoteAsset: "USDT",
+  },
+  TRXNGN: {
+    symbol: "TRXNGN",
+    baseAsset: "TRX",
+    quoteAsset: "NGN",
+  },
+  SXPTRY: {
+    symbol: "SXPTRY",
+    baseAsset: "SXP",
+    quoteAsset: "TRY",
+  },
+  UTKBTC: {
+    symbol: "UTKBTC",
+    baseAsset: "UTK",
+    quoteAsset: "BTC",
+  },
+  UTKUSDT: {
+    symbol: "UTKUSDT",
+    baseAsset: "UTK",
+    quoteAsset: "USDT",
+  },
+  XVSBNB: {
+    symbol: "XVSBNB",
+    baseAsset: "XVS",
+    quoteAsset: "BNB",
+  },
+  XVSBTC: {
+    symbol: "XVSBTC",
+    baseAsset: "XVS",
+    quoteAsset: "BTC",
+  },
+  XVSBUSD: {
+    symbol: "XVSBUSD",
+    baseAsset: "XVS",
+    quoteAsset: "BUSD",
+  },
+  XVSUSDT: {
+    symbol: "XVSUSDT",
+    baseAsset: "XVS",
+    quoteAsset: "USDT",
+  },
+  ALPHABNB: {
+    symbol: "ALPHABNB",
+    baseAsset: "ALPHA",
+    quoteAsset: "BNB",
+  },
+  ALPHABTC: {
+    symbol: "ALPHABTC",
+    baseAsset: "ALPHA",
+    quoteAsset: "BTC",
+  },
+  ALPHABUSD: {
+    symbol: "ALPHABUSD",
+    baseAsset: "ALPHA",
+    quoteAsset: "BUSD",
+  },
+  ALPHAUSDT: {
+    symbol: "ALPHAUSDT",
+    baseAsset: "ALPHA",
+    quoteAsset: "USDT",
+  },
+  VIDTBTC: {
+    symbol: "VIDTBTC",
+    baseAsset: "VIDT",
+    quoteAsset: "BTC",
+  },
+  VIDTBUSD: {
+    symbol: "VIDTBUSD",
+    baseAsset: "VIDT",
+    quoteAsset: "BUSD",
+  },
+  AAVEBNB: {
+    symbol: "AAVEBNB",
+    baseAsset: "AAVE",
+    quoteAsset: "BNB",
+  },
+  BTCBRL: {
+    symbol: "BTCBRL",
+    baseAsset: "BTC",
+    quoteAsset: "BRL",
+  },
+  USDTBRL: {
+    symbol: "USDTBRL",
+    baseAsset: "USDT",
+    quoteAsset: "BRL",
+  },
+  AAVEBTC: {
+    symbol: "AAVEBTC",
+    baseAsset: "AAVE",
+    quoteAsset: "BTC",
+  },
+  AAVEETH: {
+    symbol: "AAVEETH",
+    baseAsset: "AAVE",
+    quoteAsset: "ETH",
+  },
+  AAVEBUSD: {
+    symbol: "AAVEBUSD",
+    baseAsset: "AAVE",
+    quoteAsset: "BUSD",
+  },
+  AAVEUSDT: {
+    symbol: "AAVEUSDT",
+    baseAsset: "AAVE",
+    quoteAsset: "USDT",
+  },
+  AAVEBKRW: {
+    symbol: "AAVEBKRW",
+    baseAsset: "AAVE",
+    quoteAsset: "BKRW",
+  },
+  NEARBNB: {
+    symbol: "NEARBNB",
+    baseAsset: "NEAR",
+    quoteAsset: "BNB",
+  },
+  NEARBTC: {
+    symbol: "NEARBTC",
+    baseAsset: "NEAR",
+    quoteAsset: "BTC",
+  },
+  NEARBUSD: {
+    symbol: "NEARBUSD",
+    baseAsset: "NEAR",
+    quoteAsset: "BUSD",
+  },
+  NEARUSDT: {
+    symbol: "NEARUSDT",
+    baseAsset: "NEAR",
+    quoteAsset: "USDT",
+  },
+  SXPUPUSDT: {
+    symbol: "SXPUPUSDT",
+    baseAsset: "SXPUP",
+    quoteAsset: "USDT",
+  },
+  SXPDOWNUSDT: {
+    symbol: "SXPDOWNUSDT",
+    baseAsset: "SXPDOWN",
+    quoteAsset: "USDT",
+  },
+  DOTBKRW: {
+    symbol: "DOTBKRW",
+    baseAsset: "DOT",
+    quoteAsset: "BKRW",
+  },
+  SXPGBP: {
+    symbol: "SXPGBP",
+    baseAsset: "SXP",
+    quoteAsset: "GBP",
+  },
+  FILBNB: {
+    symbol: "FILBNB",
+    baseAsset: "FIL",
+    quoteAsset: "BNB",
+  },
+  FILBTC: {
+    symbol: "FILBTC",
+    baseAsset: "FIL",
+    quoteAsset: "BTC",
+  },
+  FILBUSD: {
+    symbol: "FILBUSD",
+    baseAsset: "FIL",
+    quoteAsset: "BUSD",
+  },
+  FILUSDT: {
+    symbol: "FILUSDT",
+    baseAsset: "FIL",
+    quoteAsset: "USDT",
+  },
+  FILUPUSDT: {
+    symbol: "FILUPUSDT",
+    baseAsset: "FILUP",
+    quoteAsset: "USDT",
+  },
+  FILDOWNUSDT: {
+    symbol: "FILDOWNUSDT",
+    baseAsset: "FILDOWN",
+    quoteAsset: "USDT",
+  },
+  YFIUPUSDT: {
+    symbol: "YFIUPUSDT",
+    baseAsset: "YFIUP",
+    quoteAsset: "USDT",
+  },
+  YFIDOWNUSDT: {
+    symbol: "YFIDOWNUSDT",
+    baseAsset: "YFIDOWN",
+    quoteAsset: "USDT",
+  },
+  INJBNB: {
+    symbol: "INJBNB",
+    baseAsset: "INJ",
+    quoteAsset: "BNB",
+  },
+  INJBTC: {
+    symbol: "INJBTC",
+    baseAsset: "INJ",
+    quoteAsset: "BTC",
+  },
+  INJBUSD: {
+    symbol: "INJBUSD",
+    baseAsset: "INJ",
+    quoteAsset: "BUSD",
+  },
+  INJUSDT: {
+    symbol: "INJUSDT",
+    baseAsset: "INJ",
+    quoteAsset: "USDT",
+  },
+  AERGOBTC: {
+    symbol: "AERGOBTC",
+    baseAsset: "AERGO",
+    quoteAsset: "BTC",
+  },
+  AERGOBUSD: {
+    symbol: "AERGOBUSD",
+    baseAsset: "AERGO",
+    quoteAsset: "BUSD",
+  },
+  LINKEUR: {
+    symbol: "LINKEUR",
+    baseAsset: "LINK",
+    quoteAsset: "EUR",
+  },
+  ONEBUSD: {
+    symbol: "ONEBUSD",
+    baseAsset: "ONE",
+    quoteAsset: "BUSD",
+  },
+  EASYETH: {
+    symbol: "EASYETH",
+    baseAsset: "EASY",
+    quoteAsset: "ETH",
+  },
+  AUDIOBTC: {
+    symbol: "AUDIOBTC",
+    baseAsset: "AUDIO",
+    quoteAsset: "BTC",
+  },
+  AUDIOBUSD: {
+    symbol: "AUDIOBUSD",
+    baseAsset: "AUDIO",
+    quoteAsset: "BUSD",
+  },
+  AUDIOUSDT: {
+    symbol: "AUDIOUSDT",
+    baseAsset: "AUDIO",
+    quoteAsset: "USDT",
+  },
+  CTKBNB: {
+    symbol: "CTKBNB",
+    baseAsset: "CTK",
+    quoteAsset: "BNB",
+  },
+  CTKBTC: {
+    symbol: "CTKBTC",
+    baseAsset: "CTK",
+    quoteAsset: "BTC",
+  },
+  CTKBUSD: {
+    symbol: "CTKBUSD",
+    baseAsset: "CTK",
+    quoteAsset: "BUSD",
+  },
+  CTKUSDT: {
+    symbol: "CTKUSDT",
+    baseAsset: "CTK",
+    quoteAsset: "USDT",
+  },
+  BCHUPUSDT: {
+    symbol: "BCHUPUSDT",
+    baseAsset: "BCHUP",
+    quoteAsset: "USDT",
+  },
+  BCHDOWNUSDT: {
+    symbol: "BCHDOWNUSDT",
+    baseAsset: "BCHDOWN",
+    quoteAsset: "USDT",
+  },
+  BOTBTC: {
+    symbol: "BOTBTC",
+    baseAsset: "BOT",
+    quoteAsset: "BTC",
+  },
+  BOTBUSD: {
+    symbol: "BOTBUSD",
+    baseAsset: "BOT",
+    quoteAsset: "BUSD",
+  },
+  ETHBRL: {
+    symbol: "ETHBRL",
+    baseAsset: "ETH",
+    quoteAsset: "BRL",
+  },
+  DOTEUR: {
+    symbol: "DOTEUR",
+    baseAsset: "DOT",
+    quoteAsset: "EUR",
+  },
+  AKROBTC: {
+    symbol: "AKROBTC",
+    baseAsset: "AKRO",
+    quoteAsset: "BTC",
+  },
+  AKROUSDT: {
+    symbol: "AKROUSDT",
+    baseAsset: "AKRO",
+    quoteAsset: "USDT",
+  },
+  KP3RBNB: {
+    symbol: "KP3RBNB",
+    baseAsset: "KP3R",
+    quoteAsset: "BNB",
+  },
+  KP3RBUSD: {
+    symbol: "KP3RBUSD",
+    baseAsset: "KP3R",
+    quoteAsset: "BUSD",
+  },
+  AXSBNB: {
+    symbol: "AXSBNB",
+    baseAsset: "AXS",
+    quoteAsset: "BNB",
+  },
+  AXSBTC: {
+    symbol: "AXSBTC",
+    baseAsset: "AXS",
+    quoteAsset: "BTC",
+  },
+  AXSBUSD: {
+    symbol: "AXSBUSD",
+    baseAsset: "AXS",
+    quoteAsset: "BUSD",
+  },
+  AXSUSDT: {
+    symbol: "AXSUSDT",
+    baseAsset: "AXS",
+    quoteAsset: "USDT",
+  },
+  HARDBNB: {
+    symbol: "HARDBNB",
+    baseAsset: "HARD",
+    quoteAsset: "BNB",
+  },
+  HARDBTC: {
+    symbol: "HARDBTC",
+    baseAsset: "HARD",
+    quoteAsset: "BTC",
+  },
+  HARDBUSD: {
+    symbol: "HARDBUSD",
+    baseAsset: "HARD",
+    quoteAsset: "BUSD",
+  },
+  HARDUSDT: {
+    symbol: "HARDUSDT",
+    baseAsset: "HARD",
+    quoteAsset: "USDT",
+  },
+  BNBBRL: {
+    symbol: "BNBBRL",
+    baseAsset: "BNB",
+    quoteAsset: "BRL",
+  },
+  LTCEUR: {
+    symbol: "LTCEUR",
+    baseAsset: "LTC",
+    quoteAsset: "EUR",
+  },
+  RENBTCBTC: {
+    symbol: "RENBTCBTC",
+    baseAsset: "RENBTC",
+    quoteAsset: "BTC",
+  },
+  RENBTCETH: {
+    symbol: "RENBTCETH",
+    baseAsset: "RENBTC",
+    quoteAsset: "ETH",
+  },
+  DNTBUSD: {
+    symbol: "DNTBUSD",
+    baseAsset: "DNT",
+    quoteAsset: "BUSD",
+  },
+  DNTUSDT: {
+    symbol: "DNTUSDT",
+    baseAsset: "DNT",
+    quoteAsset: "USDT",
+  },
+  SLPETH: {
+    symbol: "SLPETH",
+    baseAsset: "SLP",
+    quoteAsset: "ETH",
+  },
+  ADAEUR: {
+    symbol: "ADAEUR",
+    baseAsset: "ADA",
+    quoteAsset: "EUR",
+  },
+  LTCNGN: {
+    symbol: "LTCNGN",
+    baseAsset: "LTC",
+    quoteAsset: "NGN",
+  },
+  CVPETH: {
+    symbol: "CVPETH",
+    baseAsset: "CVP",
+    quoteAsset: "ETH",
+  },
+  CVPBUSD: {
+    symbol: "CVPBUSD",
+    baseAsset: "CVP",
+    quoteAsset: "BUSD",
+  },
+  STRAXBTC: {
+    symbol: "STRAXBTC",
+    baseAsset: "STRAX",
+    quoteAsset: "BTC",
+  },
+  STRAXETH: {
+    symbol: "STRAXETH",
+    baseAsset: "STRAX",
+    quoteAsset: "ETH",
+  },
+  STRAXBUSD: {
+    symbol: "STRAXBUSD",
+    baseAsset: "STRAX",
+    quoteAsset: "BUSD",
+  },
+  STRAXUSDT: {
+    symbol: "STRAXUSDT",
+    baseAsset: "STRAX",
+    quoteAsset: "USDT",
+  },
+  FORBTC: {
+    symbol: "FORBTC",
+    baseAsset: "FOR",
+    quoteAsset: "BTC",
+  },
+  FORBUSD: {
+    symbol: "FORBUSD",
+    baseAsset: "FOR",
+    quoteAsset: "BUSD",
+  },
+  UNFIBNB: {
+    symbol: "UNFIBNB",
+    baseAsset: "UNFI",
+    quoteAsset: "BNB",
+  },
+  UNFIBTC: {
+    symbol: "UNFIBTC",
+    baseAsset: "UNFI",
+    quoteAsset: "BTC",
+  },
+  UNFIBUSD: {
+    symbol: "UNFIBUSD",
+    baseAsset: "UNFI",
+    quoteAsset: "BUSD",
+  },
+  UNFIUSDT: {
+    symbol: "UNFIUSDT",
+    baseAsset: "UNFI",
+    quoteAsset: "USDT",
+  },
+  FRONTETH: {
+    symbol: "FRONTETH",
+    baseAsset: "FRONT",
+    quoteAsset: "ETH",
+  },
+  FRONTBUSD: {
+    symbol: "FRONTBUSD",
+    baseAsset: "FRONT",
+    quoteAsset: "BUSD",
+  },
+  BCHABUSD: {
+    symbol: "BCHABUSD",
+    baseAsset: "BCHA",
+    quoteAsset: "BUSD",
+  },
+  ROSEBTC: {
+    symbol: "ROSEBTC",
+    baseAsset: "ROSE",
+    quoteAsset: "BTC",
+  },
+  ROSEBUSD: {
+    symbol: "ROSEBUSD",
+    baseAsset: "ROSE",
+    quoteAsset: "BUSD",
+  },
+  ROSEUSDT: {
+    symbol: "ROSEUSDT",
+    baseAsset: "ROSE",
+    quoteAsset: "USDT",
+  },
+  AVAXTRY: {
+    symbol: "AVAXTRY",
+    baseAsset: "AVAX",
+    quoteAsset: "TRY",
+  },
+  BUSDBRL: {
+    symbol: "BUSDBRL",
+    baseAsset: "BUSD",
+    quoteAsset: "BRL",
+  },
+  AVAUSDT: {
+    symbol: "AVAUSDT",
+    baseAsset: "AVA",
+    quoteAsset: "USDT",
+  },
+  SYSBUSD: {
+    symbol: "SYSBUSD",
+    baseAsset: "SYS",
+    quoteAsset: "BUSD",
+  },
+  XEMUSDT: {
+    symbol: "XEMUSDT",
+    baseAsset: "XEM",
+    quoteAsset: "USDT",
+  },
+  HEGICETH: {
+    symbol: "HEGICETH",
+    baseAsset: "HEGIC",
+    quoteAsset: "ETH",
+  },
+  HEGICBUSD: {
+    symbol: "HEGICBUSD",
+    baseAsset: "HEGIC",
+    quoteAsset: "BUSD",
+  },
+  AAVEUPUSDT: {
+    symbol: "AAVEUPUSDT",
+    baseAsset: "AAVEUP",
+    quoteAsset: "USDT",
+  },
+  AAVEDOWNUSDT: {
+    symbol: "AAVEDOWNUSDT",
+    baseAsset: "AAVEDOWN",
+    quoteAsset: "USDT",
+  },
+  PROMBNB: {
+    symbol: "PROMBNB",
+    baseAsset: "PROM",
+    quoteAsset: "BNB",
+  },
+  PROMBUSD: {
+    symbol: "PROMBUSD",
+    baseAsset: "PROM",
+    quoteAsset: "BUSD",
+  },
+  XRPBRL: {
+    symbol: "XRPBRL",
+    baseAsset: "XRP",
+    quoteAsset: "BRL",
+  },
+  XRPNGN: {
+    symbol: "XRPNGN",
+    baseAsset: "XRP",
+    quoteAsset: "NGN",
+  },
+  SKLBTC: {
+    symbol: "SKLBTC",
+    baseAsset: "SKL",
+    quoteAsset: "BTC",
+  },
+  SKLBUSD: {
+    symbol: "SKLBUSD",
+    baseAsset: "SKL",
+    quoteAsset: "BUSD",
+  },
+  SKLUSDT: {
+    symbol: "SKLUSDT",
+    baseAsset: "SKL",
+    quoteAsset: "USDT",
+  },
+  BCHEUR: {
+    symbol: "BCHEUR",
+    baseAsset: "BCH",
+    quoteAsset: "EUR",
+  },
+  YFIEUR: {
+    symbol: "YFIEUR",
+    baseAsset: "YFI",
+    quoteAsset: "EUR",
+  },
+  ZILBIDR: {
+    symbol: "ZILBIDR",
+    baseAsset: "ZIL",
+    quoteAsset: "BIDR",
+  },
+  SUSDBTC: {
+    symbol: "SUSDBTC",
+    baseAsset: "SUSD",
+    quoteAsset: "BTC",
+  },
+  SUSDETH: {
+    symbol: "SUSDETH",
+    baseAsset: "SUSD",
+    quoteAsset: "ETH",
+  },
+  SUSDUSDT: {
+    symbol: "SUSDUSDT",
+    baseAsset: "SUSD",
+    quoteAsset: "USDT",
+  },
+  COVERETH: {
+    symbol: "COVERETH",
+    baseAsset: "COVER",
+    quoteAsset: "ETH",
+  },
+  COVERBUSD: {
+    symbol: "COVERBUSD",
+    baseAsset: "COVER",
+    quoteAsset: "BUSD",
+  },
+  GLMBTC: {
+    symbol: "GLMBTC",
+    baseAsset: "GLM",
+    quoteAsset: "BTC",
+  },
+  GLMETH: {
+    symbol: "GLMETH",
+    baseAsset: "GLM",
+    quoteAsset: "ETH",
+  },
+  GHSTETH: {
+    symbol: "GHSTETH",
+    baseAsset: "GHST",
+    quoteAsset: "ETH",
+  },
+  GHSTBUSD: {
+    symbol: "GHSTBUSD",
+    baseAsset: "GHST",
+    quoteAsset: "BUSD",
+  },
+  SUSHIUPUSDT: {
+    symbol: "SUSHIUPUSDT",
+    baseAsset: "SUSHIUP",
+    quoteAsset: "USDT",
+  },
+  SUSHIDOWNUSDT: {
+    symbol: "SUSHIDOWNUSDT",
+    baseAsset: "SUSHIDOWN",
+    quoteAsset: "USDT",
+  },
+  XLMUPUSDT: {
+    symbol: "XLMUPUSDT",
+    baseAsset: "XLMUP",
+    quoteAsset: "USDT",
+  },
+  XLMDOWNUSDT: {
+    symbol: "XLMDOWNUSDT",
+    baseAsset: "XLMDOWN",
+    quoteAsset: "USDT",
+  },
+  LINKBRL: {
+    symbol: "LINKBRL",
+    baseAsset: "LINK",
+    quoteAsset: "BRL",
+  },
+  LINKNGN: {
+    symbol: "LINKNGN",
+    baseAsset: "LINK",
+    quoteAsset: "NGN",
+  },
+  LTCRUB: {
+    symbol: "LTCRUB",
+    baseAsset: "LTC",
+    quoteAsset: "RUB",
+  },
+  TRXTRY: {
+    symbol: "TRXTRY",
+    baseAsset: "TRX",
+    quoteAsset: "TRY",
+  },
+  XLMEUR: {
+    symbol: "XLMEUR",
+    baseAsset: "XLM",
+    quoteAsset: "EUR",
+  },
+  DFETH: {
+    symbol: "DFETH",
+    baseAsset: "DF",
+    quoteAsset: "ETH",
+  },
+  DFBUSD: {
+    symbol: "DFBUSD",
+    baseAsset: "DF",
+    quoteAsset: "BUSD",
+  },
+  GRTBTC: {
+    symbol: "GRTBTC",
+    baseAsset: "GRT",
+    quoteAsset: "BTC",
+  },
+  GRTETH: {
+    symbol: "GRTETH",
+    baseAsset: "GRT",
+    quoteAsset: "ETH",
+  },
+  GRTUSDT: {
+    symbol: "GRTUSDT",
+    baseAsset: "GRT",
+    quoteAsset: "USDT",
+  },
+  JUVBTC: {
+    symbol: "JUVBTC",
+    baseAsset: "JUV",
+    quoteAsset: "BTC",
+  },
+  JUVBUSD: {
+    symbol: "JUVBUSD",
+    baseAsset: "JUV",
+    quoteAsset: "BUSD",
+  },
+  JUVUSDT: {
+    symbol: "JUVUSDT",
+    baseAsset: "JUV",
+    quoteAsset: "USDT",
+  },
+  PSGBTC: {
+    symbol: "PSGBTC",
+    baseAsset: "PSG",
+    quoteAsset: "BTC",
+  },
+  PSGBUSD: {
+    symbol: "PSGBUSD",
+    baseAsset: "PSG",
+    quoteAsset: "BUSD",
+  },
+  PSGUSDT: {
+    symbol: "PSGUSDT",
+    baseAsset: "PSG",
+    quoteAsset: "USDT",
+  },
+  BUSDBVND: {
+    symbol: "BUSDBVND",
+    baseAsset: "BUSD",
+    quoteAsset: "BVND",
+  },
+  USDTBVND: {
+    symbol: "USDTBVND",
+    baseAsset: "USDT",
+    quoteAsset: "BVND",
+  },
+  "1INCHBTC": {
+    symbol: "1INCHBTC",
+    baseAsset: "1INCH",
+    quoteAsset: "BTC",
+  },
+  "1INCHUSDT": {
+    symbol: "1INCHUSDT",
+    baseAsset: "1INCH",
+    quoteAsset: "USDT",
+  },
+  REEFBTC: {
+    symbol: "REEFBTC",
+    baseAsset: "REEF",
+    quoteAsset: "BTC",
+  },
+  REEFUSDT: {
+    symbol: "REEFUSDT",
+    baseAsset: "REEF",
+    quoteAsset: "USDT",
+  },
+  OGBTC: {
+    symbol: "OGBTC",
+    baseAsset: "OG",
+    quoteAsset: "BTC",
+  },
+  OGUSDT: {
+    symbol: "OGUSDT",
+    baseAsset: "OG",
+    quoteAsset: "USDT",
+  },
+  ATMBTC: {
+    symbol: "ATMBTC",
+    baseAsset: "ATM",
+    quoteAsset: "BTC",
+  },
+  ATMUSDT: {
+    symbol: "ATMUSDT",
+    baseAsset: "ATM",
+    quoteAsset: "USDT",
+  },
+  ASRBTC: {
+    symbol: "ASRBTC",
+    baseAsset: "ASR",
+    quoteAsset: "BTC",
+  },
+  ASRUSDT: {
+    symbol: "ASRUSDT",
+    baseAsset: "ASR",
+    quoteAsset: "USDT",
+  },
+  CELOBTC: {
+    symbol: "CELOBTC",
+    baseAsset: "CELO",
+    quoteAsset: "BTC",
+  },
+  CELOUSDT: {
+    symbol: "CELOUSDT",
+    baseAsset: "CELO",
+    quoteAsset: "USDT",
+  },
+  RIFBTC: {
+    symbol: "RIFBTC",
+    baseAsset: "RIF",
+    quoteAsset: "BTC",
+  },
+  RIFUSDT: {
+    symbol: "RIFUSDT",
+    baseAsset: "RIF",
+    quoteAsset: "USDT",
+  },
+  CHZTRY: {
+    symbol: "CHZTRY",
+    baseAsset: "CHZ",
+    quoteAsset: "TRY",
+  },
+  XLMTRY: {
+    symbol: "XLMTRY",
+    baseAsset: "XLM",
+    quoteAsset: "TRY",
+  },
+  LINKGBP: {
+    symbol: "LINKGBP",
+    baseAsset: "LINK",
+    quoteAsset: "GBP",
+  },
+  GRTEUR: {
+    symbol: "GRTEUR",
+    baseAsset: "GRT",
+    quoteAsset: "EUR",
+  },
+  BTCSTBTC: {
+    symbol: "BTCSTBTC",
+    baseAsset: "BTCST",
+    quoteAsset: "BTC",
+  },
+  BTCSTBUSD: {
+    symbol: "BTCSTBUSD",
+    baseAsset: "BTCST",
+    quoteAsset: "BUSD",
+  },
+  BTCSTUSDT: {
+    symbol: "BTCSTUSDT",
+    baseAsset: "BTCST",
+    quoteAsset: "USDT",
+  },
+  TRUBTC: {
+    symbol: "TRUBTC",
+    baseAsset: "TRU",
+    quoteAsset: "BTC",
+  },
+  TRUBUSD: {
+    symbol: "TRUBUSD",
+    baseAsset: "TRU",
+    quoteAsset: "BUSD",
+  },
+  TRUUSDT: {
+    symbol: "TRUUSDT",
+    baseAsset: "TRU",
+    quoteAsset: "USDT",
+  },
+  DEXEETH: {
+    symbol: "DEXEETH",
+    baseAsset: "DEXE",
+    quoteAsset: "ETH",
+  },
+  DEXEBUSD: {
+    symbol: "DEXEBUSD",
+    baseAsset: "DEXE",
+    quoteAsset: "BUSD",
+  },
+  EOSEUR: {
+    symbol: "EOSEUR",
+    baseAsset: "EOS",
+    quoteAsset: "EUR",
+  },
+  LTCBRL: {
+    symbol: "LTCBRL",
+    baseAsset: "LTC",
+    quoteAsset: "BRL",
+  },
+  USDCBUSD: {
+    symbol: "USDCBUSD",
+    baseAsset: "USDC",
+    quoteAsset: "BUSD",
+  },
+  TUSDBUSD: {
+    symbol: "TUSDBUSD",
+    baseAsset: "TUSD",
+    quoteAsset: "BUSD",
+  },
+  PAXBUSD: {
+    symbol: "PAXBUSD",
+    baseAsset: "PAX",
+    quoteAsset: "BUSD",
+  },
+  CKBBTC: {
+    symbol: "CKBBTC",
+    baseAsset: "CKB",
+    quoteAsset: "BTC",
+  },
+  CKBBUSD: {
+    symbol: "CKBBUSD",
+    baseAsset: "CKB",
+    quoteAsset: "BUSD",
+  },
+  CKBUSDT: {
+    symbol: "CKBUSDT",
+    baseAsset: "CKB",
+    quoteAsset: "USDT",
+  },
+  TWTBTC: {
+    symbol: "TWTBTC",
+    baseAsset: "TWT",
+    quoteAsset: "BTC",
+  },
+  TWTBUSD: {
+    symbol: "TWTBUSD",
+    baseAsset: "TWT",
+    quoteAsset: "BUSD",
+  },
+  TWTUSDT: {
+    symbol: "TWTUSDT",
+    baseAsset: "TWT",
+    quoteAsset: "USDT",
+  },
+  FIROBTC: {
+    symbol: "FIROBTC",
+    baseAsset: "FIRO",
+    quoteAsset: "BTC",
+  },
+  FIROETH: {
+    symbol: "FIROETH",
+    baseAsset: "FIRO",
+    quoteAsset: "ETH",
+  },
+  FIROUSDT: {
+    symbol: "FIROUSDT",
+    baseAsset: "FIRO",
+    quoteAsset: "USDT",
+  },
+  BETHETH: {
+    symbol: "BETHETH",
+    baseAsset: "BETH",
+    quoteAsset: "ETH",
+  },
+  DOGEEUR: {
+    symbol: "DOGEEUR",
+    baseAsset: "DOGE",
+    quoteAsset: "EUR",
+  },
+  DOGETRY: {
+    symbol: "DOGETRY",
+    baseAsset: "DOGE",
+    quoteAsset: "TRY",
+  },
+  DOGEAUD: {
+    symbol: "DOGEAUD",
+    baseAsset: "DOGE",
+    quoteAsset: "AUD",
+  },
+  DOGEBRL: {
+    symbol: "DOGEBRL",
+    baseAsset: "DOGE",
+    quoteAsset: "BRL",
+  },
+  DOTNGN: {
+    symbol: "DOTNGN",
+    baseAsset: "DOT",
+    quoteAsset: "NGN",
+  },
+  PROSETH: {
+    symbol: "PROSETH",
+    baseAsset: "PROS",
+    quoteAsset: "ETH",
+  },
+  LITBTC: {
+    symbol: "LITBTC",
+    baseAsset: "LIT",
+    quoteAsset: "BTC",
+  },
+  LITBUSD: {
+    symbol: "LITBUSD",
+    baseAsset: "LIT",
+    quoteAsset: "BUSD",
+  },
+  LITUSDT: {
+    symbol: "LITUSDT",
+    baseAsset: "LIT",
+    quoteAsset: "USDT",
+  },
+  BTCVAI: {
+    symbol: "BTCVAI",
+    baseAsset: "BTC",
+    quoteAsset: "VAI",
+  },
+  BUSDVAI: {
+    symbol: "BUSDVAI",
+    baseAsset: "BUSD",
+    quoteAsset: "VAI",
+  },
+  SFPBTC: {
+    symbol: "SFPBTC",
+    baseAsset: "SFP",
+    quoteAsset: "BTC",
+  },
+  SFPBUSD: {
+    symbol: "SFPBUSD",
+    baseAsset: "SFP",
+    quoteAsset: "BUSD",
+  },
+  SFPUSDT: {
+    symbol: "SFPUSDT",
+    baseAsset: "SFP",
+    quoteAsset: "USDT",
+  },
+  DOGEGBP: {
+    symbol: "DOGEGBP",
+    baseAsset: "DOGE",
+    quoteAsset: "GBP",
+  },
+  DOTTRY: {
+    symbol: "DOTTRY",
+    baseAsset: "DOT",
+    quoteAsset: "TRY",
+  },
+  FXSBTC: {
+    symbol: "FXSBTC",
+    baseAsset: "FXS",
+    quoteAsset: "BTC",
+  },
+  FXSBUSD: {
+    symbol: "FXSBUSD",
+    baseAsset: "FXS",
+    quoteAsset: "BUSD",
+  },
+  DODOBTC: {
+    symbol: "DODOBTC",
+    baseAsset: "DODO",
+    quoteAsset: "BTC",
+  },
+  DODOBUSD: {
+    symbol: "DODOBUSD",
+    baseAsset: "DODO",
+    quoteAsset: "BUSD",
+  },
+  DODOUSDT: {
+    symbol: "DODOUSDT",
+    baseAsset: "DODO",
+    quoteAsset: "USDT",
+  },
+  FRONTBTC: {
+    symbol: "FRONTBTC",
+    baseAsset: "FRONT",
+    quoteAsset: "BTC",
+  },
+  EASYBTC: {
+    symbol: "EASYBTC",
+    baseAsset: "EASY",
+    quoteAsset: "BTC",
+  },
+  CAKEBTC: {
+    symbol: "CAKEBTC",
+    baseAsset: "CAKE",
+    quoteAsset: "BTC",
+  },
+  CAKEUSDT: {
+    symbol: "CAKEUSDT",
+    baseAsset: "CAKE",
+    quoteAsset: "USDT",
+  },
+  BAKEBUSD: {
+    symbol: "BAKEBUSD",
+    baseAsset: "BAKE",
+    quoteAsset: "BUSD",
+  },
+  UFTETH: {
+    symbol: "UFTETH",
+    baseAsset: "UFT",
+    quoteAsset: "ETH",
+  },
+  UFTBUSD: {
+    symbol: "UFTBUSD",
+    baseAsset: "UFT",
+    quoteAsset: "BUSD",
+  },
+  "1INCHBUSD": {
+    symbol: "1INCHBUSD",
+    baseAsset: "1INCH",
+    quoteAsset: "BUSD",
+  },
+  BANDBUSD: {
+    symbol: "BANDBUSD",
+    baseAsset: "BAND",
+    quoteAsset: "BUSD",
+  },
+  GRTBUSD: {
+    symbol: "GRTBUSD",
+    baseAsset: "GRT",
+    quoteAsset: "BUSD",
+  },
+  IOSTBUSD: {
+    symbol: "IOSTBUSD",
+    baseAsset: "IOST",
+    quoteAsset: "BUSD",
+  },
+  OMGBUSD: {
+    symbol: "OMGBUSD",
+    baseAsset: "OMG",
+    quoteAsset: "BUSD",
+  },
+  REEFBUSD: {
+    symbol: "REEFBUSD",
+    baseAsset: "REEF",
+    quoteAsset: "BUSD",
+  },
+  ACMBTC: {
+    symbol: "ACMBTC",
+    baseAsset: "ACM",
+    quoteAsset: "BTC",
+  },
+  ACMBUSD: {
+    symbol: "ACMBUSD",
+    baseAsset: "ACM",
+    quoteAsset: "BUSD",
+  },
+  ACMUSDT: {
+    symbol: "ACMUSDT",
+    baseAsset: "ACM",
+    quoteAsset: "USDT",
+  },
+  AUCTIONBTC: {
+    symbol: "AUCTIONBTC",
+    baseAsset: "AUCTION",
+    quoteAsset: "BTC",
+  },
+  AUCTIONBUSD: {
+    symbol: "AUCTIONBUSD",
+    baseAsset: "AUCTION",
+    quoteAsset: "BUSD",
+  },
+  PHABTC: {
+    symbol: "PHABTC",
+    baseAsset: "PHA",
+    quoteAsset: "BTC",
+  },
+  PHABUSD: {
+    symbol: "PHABUSD",
+    baseAsset: "PHA",
+    quoteAsset: "BUSD",
+  },
+  DOTGBP: {
+    symbol: "DOTGBP",
+    baseAsset: "DOT",
+    quoteAsset: "GBP",
+  },
+  ADATRY: {
+    symbol: "ADATRY",
+    baseAsset: "ADA",
+    quoteAsset: "TRY",
+  },
+  ADABRL: {
+    symbol: "ADABRL",
+    baseAsset: "ADA",
+    quoteAsset: "BRL",
+  },
+  ADAGBP: {
+    symbol: "ADAGBP",
+    baseAsset: "ADA",
+    quoteAsset: "GBP",
+  },
+  TVKBTC: {
+    symbol: "TVKBTC",
+    baseAsset: "TVK",
+    quoteAsset: "BTC",
+  },
+  TVKBUSD: {
+    symbol: "TVKBUSD",
+    baseAsset: "TVK",
+    quoteAsset: "BUSD",
+  },
+  BADGERBTC: {
+    symbol: "BADGERBTC",
+    baseAsset: "BADGER",
+    quoteAsset: "BTC",
+  },
+  BADGERBUSD: {
+    symbol: "BADGERBUSD",
+    baseAsset: "BADGER",
+    quoteAsset: "BUSD",
+  },
+  BADGERUSDT: {
+    symbol: "BADGERUSDT",
+    baseAsset: "BADGER",
+    quoteAsset: "USDT",
+  },
+  FISBTC: {
+    symbol: "FISBTC",
+    baseAsset: "FIS",
+    quoteAsset: "BTC",
+  },
+  FISBUSD: {
+    symbol: "FISBUSD",
+    baseAsset: "FIS",
+    quoteAsset: "BUSD",
+  },
+  FISUSDT: {
+    symbol: "FISUSDT",
+    baseAsset: "FIS",
+    quoteAsset: "USDT",
+  },
+  DOTBRL: {
+    symbol: "DOTBRL",
+    baseAsset: "DOT",
+    quoteAsset: "BRL",
+  },
+  ADAAUD: {
+    symbol: "ADAAUD",
+    baseAsset: "ADA",
+    quoteAsset: "AUD",
+  },
+  HOTTRY: {
+    symbol: "HOTTRY",
+    baseAsset: "HOT",
+    quoteAsset: "TRY",
+  },
+  EGLDEUR: {
+    symbol: "EGLDEUR",
+    baseAsset: "EGLD",
+    quoteAsset: "EUR",
+  },
+  OMBTC: {
+    symbol: "OMBTC",
+    baseAsset: "OM",
+    quoteAsset: "BTC",
+  },
+  OMBUSD: {
+    symbol: "OMBUSD",
+    baseAsset: "OM",
+    quoteAsset: "BUSD",
+  },
+  OMUSDT: {
+    symbol: "OMUSDT",
+    baseAsset: "OM",
+    quoteAsset: "USDT",
+  },
+  PONDBTC: {
+    symbol: "PONDBTC",
+    baseAsset: "POND",
+    quoteAsset: "BTC",
+  },
+  PONDBUSD: {
+    symbol: "PONDBUSD",
+    baseAsset: "POND",
+    quoteAsset: "BUSD",
+  },
+  PONDUSDT: {
+    symbol: "PONDUSDT",
+    baseAsset: "POND",
+    quoteAsset: "USDT",
+  },
+  DEGOBTC: {
+    symbol: "DEGOBTC",
+    baseAsset: "DEGO",
+    quoteAsset: "BTC",
+  },
+  DEGOBUSD: {
+    symbol: "DEGOBUSD",
+    baseAsset: "DEGO",
+    quoteAsset: "BUSD",
+  },
+  DEGOUSDT: {
+    symbol: "DEGOUSDT",
+    baseAsset: "DEGO",
+    quoteAsset: "USDT",
+  },
+  AVAXEUR: {
+    symbol: "AVAXEUR",
+    baseAsset: "AVAX",
+    quoteAsset: "EUR",
+  },
+  BTTTRY: {
+    symbol: "BTTTRY",
+    baseAsset: "BTT",
+    quoteAsset: "TRY",
+  },
+  CHZBRL: {
+    symbol: "CHZBRL",
+    baseAsset: "CHZ",
+    quoteAsset: "BRL",
+  },
+  UNIEUR: {
+    symbol: "UNIEUR",
+    baseAsset: "UNI",
+    quoteAsset: "EUR",
+  },
+  ALICEBTC: {
+    symbol: "ALICEBTC",
+    baseAsset: "ALICE",
+    quoteAsset: "BTC",
+  },
+  ALICEBUSD: {
+    symbol: "ALICEBUSD",
+    baseAsset: "ALICE",
+    quoteAsset: "BUSD",
+  },
+  ALICEUSDT: {
+    symbol: "ALICEUSDT",
+    baseAsset: "ALICE",
+    quoteAsset: "USDT",
+  },
+  CHZBUSD: {
+    symbol: "CHZBUSD",
+    baseAsset: "CHZ",
+    quoteAsset: "BUSD",
+  },
+  CHZEUR: {
+    symbol: "CHZEUR",
+    baseAsset: "CHZ",
+    quoteAsset: "EUR",
+  },
+  CHZGBP: {
+    symbol: "CHZGBP",
+    baseAsset: "CHZ",
+    quoteAsset: "GBP",
+  },
+  BIFIBNB: {
+    symbol: "BIFIBNB",
+    baseAsset: "BIFI",
+    quoteAsset: "BNB",
+  },
+  BIFIBUSD: {
+    symbol: "BIFIBUSD",
+    baseAsset: "BIFI",
+    quoteAsset: "BUSD",
+  },
+  LINABTC: {
+    symbol: "LINABTC",
+    baseAsset: "LINA",
+    quoteAsset: "BTC",
+  },
+  LINABUSD: {
+    symbol: "LINABUSD",
+    baseAsset: "LINA",
+    quoteAsset: "BUSD",
+  },
+  LINAUSDT: {
+    symbol: "LINAUSDT",
+    baseAsset: "LINA",
+    quoteAsset: "USDT",
+  },
+  ADARUB: {
+    symbol: "ADARUB",
+    baseAsset: "ADA",
+    quoteAsset: "RUB",
+  },
+  ENJBRL: {
+    symbol: "ENJBRL",
+    baseAsset: "ENJ",
+    quoteAsset: "BRL",
+  },
+  ENJEUR: {
+    symbol: "ENJEUR",
+    baseAsset: "ENJ",
+    quoteAsset: "EUR",
+  },
+  MATICEUR: {
+    symbol: "MATICEUR",
+    baseAsset: "MATIC",
+    quoteAsset: "EUR",
+  },
+  NEOTRY: {
+    symbol: "NEOTRY",
+    baseAsset: "NEO",
+    quoteAsset: "TRY",
+  },
+  PERPBTC: {
+    symbol: "PERPBTC",
+    baseAsset: "PERP",
+    quoteAsset: "BTC",
+  },
+  PERPBUSD: {
+    symbol: "PERPBUSD",
+    baseAsset: "PERP",
+    quoteAsset: "BUSD",
+  },
+  PERPUSDT: {
+    symbol: "PERPUSDT",
+    baseAsset: "PERP",
+    quoteAsset: "USDT",
+  },
+  RAMPBTC: {
+    symbol: "RAMPBTC",
+    baseAsset: "RAMP",
+    quoteAsset: "BTC",
+  },
+  RAMPBUSD: {
+    symbol: "RAMPBUSD",
+    baseAsset: "RAMP",
+    quoteAsset: "BUSD",
+  },
+  RAMPUSDT: {
+    symbol: "RAMPUSDT",
+    baseAsset: "RAMP",
+    quoteAsset: "USDT",
+  },
+  SUPERBTC: {
+    symbol: "SUPERBTC",
+    baseAsset: "SUPER",
+    quoteAsset: "BTC",
+  },
+  SUPERBUSD: {
+    symbol: "SUPERBUSD",
+    baseAsset: "SUPER",
+    quoteAsset: "BUSD",
+  },
+  SUPERUSDT: {
+    symbol: "SUPERUSDT",
+    baseAsset: "SUPER",
+    quoteAsset: "USDT",
+  },
+  CFXBTC: {
+    symbol: "CFXBTC",
+    baseAsset: "CFX",
+    quoteAsset: "BTC",
+  },
+  CFXBUSD: {
+    symbol: "CFXBUSD",
+    baseAsset: "CFX",
+    quoteAsset: "BUSD",
+  },
+  CFXUSDT: {
+    symbol: "CFXUSDT",
+    baseAsset: "CFX",
+    quoteAsset: "USDT",
+  },
+  ENJGBP: {
+    symbol: "ENJGBP",
+    baseAsset: "ENJ",
+    quoteAsset: "GBP",
+  },
+  EOSTRY: {
+    symbol: "EOSTRY",
+    baseAsset: "EOS",
+    quoteAsset: "TRY",
+  },
+  LTCGBP: {
+    symbol: "LTCGBP",
+    baseAsset: "LTC",
+    quoteAsset: "GBP",
+  },
+  LUNAEUR: {
+    symbol: "LUNAEUR",
+    baseAsset: "LUNA",
+    quoteAsset: "EUR",
+  },
+  RVNTRY: {
+    symbol: "RVNTRY",
+    baseAsset: "RVN",
+    quoteAsset: "TRY",
+  },
+  THETAEUR: {
+    symbol: "THETAEUR",
+    baseAsset: "THETA",
+    quoteAsset: "EUR",
+  },
+  XVGBUSD: {
+    symbol: "XVGBUSD",
+    baseAsset: "XVG",
+    quoteAsset: "BUSD",
+  },
+  EPSBTC: {
+    symbol: "EPSBTC",
+    baseAsset: "EPS",
+    quoteAsset: "BTC",
+  },
+  EPSBUSD: {
+    symbol: "EPSBUSD",
+    baseAsset: "EPS",
+    quoteAsset: "BUSD",
+  },
+  EPSUSDT: {
+    symbol: "EPSUSDT",
+    baseAsset: "EPS",
+    quoteAsset: "USDT",
+  },
+  AUTOBTC: {
+    symbol: "AUTOBTC",
+    baseAsset: "AUTO",
+    quoteAsset: "BTC",
+  },
+  AUTOBUSD: {
+    symbol: "AUTOBUSD",
+    baseAsset: "AUTO",
+    quoteAsset: "BUSD",
+  },
+  AUTOUSDT: {
+    symbol: "AUTOUSDT",
+    baseAsset: "AUTO",
+    quoteAsset: "USDT",
+  },
+  TKOBTC: {
+    symbol: "TKOBTC",
+    baseAsset: "TKO",
+    quoteAsset: "BTC",
+  },
+  TKOBIDR: {
+    symbol: "TKOBIDR",
+    baseAsset: "TKO",
+    quoteAsset: "BIDR",
+  },
+  TKOBUSD: {
+    symbol: "TKOBUSD",
+    baseAsset: "TKO",
+    quoteAsset: "BUSD",
+  },
+  TKOUSDT: {
+    symbol: "TKOUSDT",
+    baseAsset: "TKO",
+    quoteAsset: "USDT",
+  },
+  PUNDIXETH: {
+    symbol: "PUNDIXETH",
+    baseAsset: "PUNDIX",
+    quoteAsset: "ETH",
+  },
+  PUNDIXUSDT: {
+    symbol: "PUNDIXUSDT",
+    baseAsset: "PUNDIX",
+    quoteAsset: "USDT",
+  },
+  BTTBRL: {
+    symbol: "BTTBRL",
+    baseAsset: "BTT",
+    quoteAsset: "BRL",
+  },
+  BTTEUR: {
+    symbol: "BTTEUR",
+    baseAsset: "BTT",
+    quoteAsset: "EUR",
+  },
+  HOTEUR: {
+    symbol: "HOTEUR",
+    baseAsset: "HOT",
+    quoteAsset: "EUR",
+  },
+  WINEUR: {
+    symbol: "WINEUR",
+    baseAsset: "WIN",
+    quoteAsset: "EUR",
+  },
+  TLMBTC: {
+    symbol: "TLMBTC",
+    baseAsset: "TLM",
+    quoteAsset: "BTC",
+  },
+  TLMBUSD: {
+    symbol: "TLMBUSD",
+    baseAsset: "TLM",
+    quoteAsset: "BUSD",
+  },
+  TLMUSDT: {
+    symbol: "TLMUSDT",
+    baseAsset: "TLM",
+    quoteAsset: "USDT",
+  },
+  "1INCHUPUSDT": {
+    symbol: "1INCHUPUSDT",
+    baseAsset: "1INCHUP",
+    quoteAsset: "USDT",
+  },
+  "1INCHDOWNUSDT": {
+    symbol: "1INCHDOWNUSDT",
+    baseAsset: "1INCHDOWN",
+    quoteAsset: "USDT",
+  },
+  BTGBUSD: {
+    symbol: "BTGBUSD",
+    baseAsset: "BTG",
+    quoteAsset: "BUSD",
+  },
+  BTGUSDT: {
+    symbol: "BTGUSDT",
+    baseAsset: "BTG",
+    quoteAsset: "USDT",
+  },
+  HOTBUSD: {
+    symbol: "HOTBUSD",
+    baseAsset: "HOT",
+    quoteAsset: "BUSD",
+  },
+  BNBUAH: {
+    symbol: "BNBUAH",
+    baseAsset: "BNB",
+    quoteAsset: "UAH",
+  },
+  ONTTRY: {
+    symbol: "ONTTRY",
+    baseAsset: "ONT",
+    quoteAsset: "TRY",
+  },
+  VETEUR: {
+    symbol: "VETEUR",
+    baseAsset: "VET",
+    quoteAsset: "EUR",
+  },
+  VETGBP: {
+    symbol: "VETGBP",
+    baseAsset: "VET",
+    quoteAsset: "GBP",
+  },
+  WINBRL: {
+    symbol: "WINBRL",
+    baseAsset: "WIN",
+    quoteAsset: "BRL",
+  },
+  MIRBTC: {
+    symbol: "MIRBTC",
+    baseAsset: "MIR",
+    quoteAsset: "BTC",
+  },
+  MIRBUSD: {
+    symbol: "MIRBUSD",
+    baseAsset: "MIR",
+    quoteAsset: "BUSD",
+  },
+  MIRUSDT: {
+    symbol: "MIRUSDT",
+    baseAsset: "MIR",
+    quoteAsset: "USDT",
+  },
+  BARBTC: {
+    symbol: "BARBTC",
+    baseAsset: "BAR",
+    quoteAsset: "BTC",
+  },
+  BARBUSD: {
+    symbol: "BARBUSD",
+    baseAsset: "BAR",
+    quoteAsset: "BUSD",
+  },
+  BARUSDT: {
+    symbol: "BARUSDT",
+    baseAsset: "BAR",
+    quoteAsset: "USDT",
+  },
+  FORTHBTC: {
+    symbol: "FORTHBTC",
+    baseAsset: "FORTH",
+    quoteAsset: "BTC",
+  },
+  FORTHBUSD: {
+    symbol: "FORTHBUSD",
+    baseAsset: "FORTH",
+    quoteAsset: "BUSD",
+  },
+  FORTHUSDT: {
+    symbol: "FORTHUSDT",
+    baseAsset: "FORTH",
+    quoteAsset: "USDT",
+  },
+  CAKEGBP: {
+    symbol: "CAKEGBP",
+    baseAsset: "CAKE",
+    quoteAsset: "GBP",
+  },
+  DOGERUB: {
+    symbol: "DOGERUB",
+    baseAsset: "DOGE",
+    quoteAsset: "RUB",
+  },
+  HOTBRL: {
+    symbol: "HOTBRL",
+    baseAsset: "HOT",
+    quoteAsset: "BRL",
+  },
+  WRXEUR: {
+    symbol: "WRXEUR",
+    baseAsset: "WRX",
+    quoteAsset: "EUR",
+  },
+  EZBTC: {
+    symbol: "EZBTC",
+    baseAsset: "EZ",
+    quoteAsset: "BTC",
+  },
+  EZETH: {
+    symbol: "EZETH",
+    baseAsset: "EZ",
+    quoteAsset: "ETH",
+  },
+  BAKEUSDT: {
+    symbol: "BAKEUSDT",
+    baseAsset: "BAKE",
+    quoteAsset: "USDT",
+  },
+  BURGERBUSD: {
+    symbol: "BURGERBUSD",
+    baseAsset: "BURGER",
+    quoteAsset: "BUSD",
+  },
+  BURGERUSDT: {
+    symbol: "BURGERUSDT",
+    baseAsset: "BURGER",
+    quoteAsset: "USDT",
+  },
+  SLPBUSD: {
+    symbol: "SLPBUSD",
+    baseAsset: "SLP",
+    quoteAsset: "BUSD",
+  },
+  SLPUSDT: {
+    symbol: "SLPUSDT",
+    baseAsset: "SLP",
+    quoteAsset: "USDT",
+  },
+  TRXAUD: {
+    symbol: "TRXAUD",
+    baseAsset: "TRX",
+    quoteAsset: "AUD",
+  },
+  TRXEUR: {
+    symbol: "TRXEUR",
+    baseAsset: "TRX",
+    quoteAsset: "EUR",
+  },
+  VETTRY: {
+    symbol: "VETTRY",
+    baseAsset: "VET",
+    quoteAsset: "TRY",
+  },
+  SHIBUSDT: {
+    symbol: "SHIBUSDT",
+    baseAsset: "SHIB",
+    quoteAsset: "USDT",
+  },
+  SHIBBUSD: {
+    symbol: "SHIBBUSD",
+    baseAsset: "SHIB",
+    quoteAsset: "BUSD",
+  },
+  ICPBTC: {
+    symbol: "ICPBTC",
+    baseAsset: "ICP",
+    quoteAsset: "BTC",
+  },
+  ICPBNB: {
+    symbol: "ICPBNB",
+    baseAsset: "ICP",
+    quoteAsset: "BNB",
+  },
+  ICPBUSD: {
+    symbol: "ICPBUSD",
+    baseAsset: "ICP",
+    quoteAsset: "BUSD",
+  },
+  ICPUSDT: {
+    symbol: "ICPUSDT",
+    baseAsset: "ICP",
+    quoteAsset: "USDT",
+  },
+  BTCGYEN: {
+    symbol: "BTCGYEN",
+    baseAsset: "BTC",
+    quoteAsset: "GYEN",
+  },
+  USDTGYEN: {
+    symbol: "USDTGYEN",
+    baseAsset: "USDT",
+    quoteAsset: "GYEN",
+  },
+  SHIBEUR: {
+    symbol: "SHIBEUR",
+    baseAsset: "SHIB",
+    quoteAsset: "EUR",
+  },
+  SHIBRUB: {
+    symbol: "SHIBRUB",
+    baseAsset: "SHIB",
+    quoteAsset: "RUB",
+  },
+  ETCEUR: {
+    symbol: "ETCEUR",
+    baseAsset: "ETC",
+    quoteAsset: "EUR",
+  },
+  ETCBRL: {
+    symbol: "ETCBRL",
+    baseAsset: "ETC",
+    quoteAsset: "BRL",
+  },
+  DOGEBIDR: {
+    symbol: "DOGEBIDR",
+    baseAsset: "DOGE",
+    quoteAsset: "BIDR",
+  },
+  ARBTC: {
+    symbol: "ARBTC",
+    baseAsset: "AR",
+    quoteAsset: "BTC",
+  },
+  ARBNB: {
+    symbol: "ARBNB",
+    baseAsset: "AR",
+    quoteAsset: "BNB",
+  },
+  ARBUSD: {
+    symbol: "ARBUSD",
+    baseAsset: "AR",
+    quoteAsset: "BUSD",
+  },
+  ARUSDT: {
+    symbol: "ARUSDT",
+    baseAsset: "AR",
+    quoteAsset: "USDT",
+  },
+  POLSBTC: {
+    symbol: "POLSBTC",
+    baseAsset: "POLS",
+    quoteAsset: "BTC",
+  },
+  POLSBNB: {
+    symbol: "POLSBNB",
+    baseAsset: "POLS",
+    quoteAsset: "BNB",
+  },
+  POLSBUSD: {
+    symbol: "POLSBUSD",
+    baseAsset: "POLS",
+    quoteAsset: "BUSD",
+  },
+  POLSUSDT: {
+    symbol: "POLSUSDT",
+    baseAsset: "POLS",
+    quoteAsset: "USDT",
+  },
+  MDXBTC: {
+    symbol: "MDXBTC",
+    baseAsset: "MDX",
+    quoteAsset: "BTC",
+  },
+  MDXBNB: {
+    symbol: "MDXBNB",
+    baseAsset: "MDX",
+    quoteAsset: "BNB",
+  },
+  MDXBUSD: {
+    symbol: "MDXBUSD",
+    baseAsset: "MDX",
+    quoteAsset: "BUSD",
+  },
+  MDXUSDT: {
+    symbol: "MDXUSDT",
+    baseAsset: "MDX",
+    quoteAsset: "USDT",
+  },
+  MASKBNB: {
+    symbol: "MASKBNB",
+    baseAsset: "MASK",
+    quoteAsset: "BNB",
+  },
+  MASKBUSD: {
+    symbol: "MASKBUSD",
+    baseAsset: "MASK",
+    quoteAsset: "BUSD",
+  },
+  MASKUSDT: {
+    symbol: "MASKUSDT",
+    baseAsset: "MASK",
+    quoteAsset: "USDT",
+  },
+  LPTBTC: {
+    symbol: "LPTBTC",
+    baseAsset: "LPT",
+    quoteAsset: "BTC",
+  },
+  LPTBNB: {
+    symbol: "LPTBNB",
+    baseAsset: "LPT",
+    quoteAsset: "BNB",
+  },
+  LPTBUSD: {
+    symbol: "LPTBUSD",
+    baseAsset: "LPT",
+    quoteAsset: "BUSD",
+  },
+  LPTUSDT: {
+    symbol: "LPTUSDT",
+    baseAsset: "LPT",
+    quoteAsset: "USDT",
+  },
+  ETHUAH: {
+    symbol: "ETHUAH",
+    baseAsset: "ETH",
+    quoteAsset: "UAH",
+  },
+  MATICBRL: {
+    symbol: "MATICBRL",
+    baseAsset: "MATIC",
+    quoteAsset: "BRL",
+  },
+  SOLEUR: {
+    symbol: "SOLEUR",
+    baseAsset: "SOL",
+    quoteAsset: "EUR",
+  },
+  SHIBBRL: {
+    symbol: "SHIBBRL",
+    baseAsset: "SHIB",
+    quoteAsset: "BRL",
+  },
+  AGIXBTC: {
+    symbol: "AGIXBTC",
+    baseAsset: "AGIX",
+    quoteAsset: "BTC",
+  },
+  ICPEUR: {
+    symbol: "ICPEUR",
+    baseAsset: "ICP",
+    quoteAsset: "EUR",
+  },
+  MATICGBP: {
+    symbol: "MATICGBP",
+    baseAsset: "MATIC",
+    quoteAsset: "GBP",
+  },
+  SHIBTRY: {
+    symbol: "SHIBTRY",
+    baseAsset: "SHIB",
+    quoteAsset: "TRY",
+  },
+  MATICBIDR: {
+    symbol: "MATICBIDR",
+    baseAsset: "MATIC",
+    quoteAsset: "BIDR",
+  },
+  MATICRUB: {
+    symbol: "MATICRUB",
+    baseAsset: "MATIC",
+    quoteAsset: "RUB",
+  },
+  NUBTC: {
+    symbol: "NUBTC",
+    baseAsset: "NU",
+    quoteAsset: "BTC",
+  },
+  NUBNB: {
+    symbol: "NUBNB",
+    baseAsset: "NU",
+    quoteAsset: "BNB",
+  },
+  NUBUSD: {
+    symbol: "NUBUSD",
+    baseAsset: "NU",
+    quoteAsset: "BUSD",
+  },
+  NUUSDT: {
+    symbol: "NUUSDT",
+    baseAsset: "NU",
+    quoteAsset: "USDT",
+  },
+  XVGUSDT: {
+    symbol: "XVGUSDT",
+    baseAsset: "XVG",
+    quoteAsset: "USDT",
+  },
+  RLCBUSD: {
+    symbol: "RLCBUSD",
+    baseAsset: "RLC",
+    quoteAsset: "BUSD",
+  },
+  CELRBUSD: {
+    symbol: "CELRBUSD",
+    baseAsset: "CELR",
+    quoteAsset: "BUSD",
+  },
+  ATMBUSD: {
+    symbol: "ATMBUSD",
+    baseAsset: "ATM",
+    quoteAsset: "BUSD",
+  },
+  ZENBUSD: {
+    symbol: "ZENBUSD",
+    baseAsset: "ZEN",
+    quoteAsset: "BUSD",
+  },
+  FTMBUSD: {
+    symbol: "FTMBUSD",
+    baseAsset: "FTM",
+    quoteAsset: "BUSD",
+  },
+  THETABUSD: {
+    symbol: "THETABUSD",
+    baseAsset: "THETA",
+    quoteAsset: "BUSD",
+  },
+  WINBUSD: {
+    symbol: "WINBUSD",
+    baseAsset: "WIN",
+    quoteAsset: "BUSD",
+  },
+  KAVABUSD: {
+    symbol: "KAVABUSD",
+    baseAsset: "KAVA",
+    quoteAsset: "BUSD",
+  },
+  XEMBUSD: {
+    symbol: "XEMBUSD",
+    baseAsset: "XEM",
+    quoteAsset: "BUSD",
+  },
+  ATABTC: {
+    symbol: "ATABTC",
+    baseAsset: "ATA",
+    quoteAsset: "BTC",
+  },
+  ATABNB: {
+    symbol: "ATABNB",
+    baseAsset: "ATA",
+    quoteAsset: "BNB",
+  },
+  ATABUSD: {
+    symbol: "ATABUSD",
+    baseAsset: "ATA",
+    quoteAsset: "BUSD",
+  },
+  ATAUSDT: {
+    symbol: "ATAUSDT",
+    baseAsset: "ATA",
+    quoteAsset: "USDT",
+  },
+  GTCBTC: {
+    symbol: "GTCBTC",
+    baseAsset: "GTC",
+    quoteAsset: "BTC",
+  },
+  GTCBNB: {
+    symbol: "GTCBNB",
+    baseAsset: "GTC",
+    quoteAsset: "BNB",
+  },
+  GTCBUSD: {
+    symbol: "GTCBUSD",
+    baseAsset: "GTC",
+    quoteAsset: "BUSD",
+  },
+  GTCUSDT: {
+    symbol: "GTCUSDT",
+    baseAsset: "GTC",
+    quoteAsset: "USDT",
+  },
+  TORNBTC: {
+    symbol: "TORNBTC",
+    baseAsset: "TORN",
+    quoteAsset: "BTC",
+  },
+  TORNBNB: {
+    symbol: "TORNBNB",
+    baseAsset: "TORN",
+    quoteAsset: "BNB",
+  },
+  TORNBUSD: {
+    symbol: "TORNBUSD",
+    baseAsset: "TORN",
+    quoteAsset: "BUSD",
+  },
+  TORNUSDT: {
+    symbol: "TORNUSDT",
+    baseAsset: "TORN",
+    quoteAsset: "USDT",
+  },
+  MATICTRY: {
+    symbol: "MATICTRY",
+    baseAsset: "MATIC",
+    quoteAsset: "TRY",
+  },
+  ETCGBP: {
+    symbol: "ETCGBP",
+    baseAsset: "ETC",
+    quoteAsset: "GBP",
+  },
+  SOLGBP: {
+    symbol: "SOLGBP",
+    baseAsset: "SOL",
+    quoteAsset: "GBP",
+  },
+  BAKEBTC: {
+    symbol: "BAKEBTC",
+    baseAsset: "BAKE",
+    quoteAsset: "BTC",
+  },
+  COTIBUSD: {
+    symbol: "COTIBUSD",
+    baseAsset: "COTI",
+    quoteAsset: "BUSD",
+  },
+  KEEPBTC: {
+    symbol: "KEEPBTC",
+    baseAsset: "KEEP",
+    quoteAsset: "BTC",
+  },
+  KEEPBNB: {
+    symbol: "KEEPBNB",
+    baseAsset: "KEEP",
+    quoteAsset: "BNB",
+  },
+  KEEPBUSD: {
+    symbol: "KEEPBUSD",
+    baseAsset: "KEEP",
+    quoteAsset: "BUSD",
+  },
+  KEEPUSDT: {
+    symbol: "KEEPUSDT",
+    baseAsset: "KEEP",
+    quoteAsset: "USDT",
+  },
+  SOLTRY: {
+    symbol: "SOLTRY",
+    baseAsset: "SOL",
+    quoteAsset: "TRY",
+  },
+  RUNEGBP: {
+    symbol: "RUNEGBP",
+    baseAsset: "RUNE",
+    quoteAsset: "GBP",
+  },
+  SOLBRL: {
+    symbol: "SOLBRL",
+    baseAsset: "SOL",
+    quoteAsset: "BRL",
+  },
+  SCBUSD: {
+    symbol: "SCBUSD",
+    baseAsset: "SC",
+    quoteAsset: "BUSD",
+  },
+  CHRBUSD: {
+    symbol: "CHRBUSD",
+    baseAsset: "CHR",
+    quoteAsset: "BUSD",
+  },
+  STMXBUSD: {
+    symbol: "STMXBUSD",
+    baseAsset: "STMX",
+    quoteAsset: "BUSD",
+  },
+  HNTBUSD: {
+    symbol: "HNTBUSD",
+    baseAsset: "HNT",
+    quoteAsset: "BUSD",
+  },
+  FTTBUSD: {
+    symbol: "FTTBUSD",
+    baseAsset: "FTT",
+    quoteAsset: "BUSD",
+  },
+  DOCKBUSD: {
+    symbol: "DOCKBUSD",
+    baseAsset: "DOCK",
+    quoteAsset: "BUSD",
+  },
+  ADABIDR: {
+    symbol: "ADABIDR",
+    baseAsset: "ADA",
+    quoteAsset: "BIDR",
+  },
+  ERNBNB: {
+    symbol: "ERNBNB",
+    baseAsset: "ERN",
+    quoteAsset: "BNB",
+  },
+  ERNBUSD: {
+    symbol: "ERNBUSD",
+    baseAsset: "ERN",
+    quoteAsset: "BUSD",
+  },
+  ERNUSDT: {
+    symbol: "ERNUSDT",
+    baseAsset: "ERN",
+    quoteAsset: "USDT",
+  },
+  KLAYBTC: {
+    symbol: "KLAYBTC",
+    baseAsset: "KLAY",
+    quoteAsset: "BTC",
+  },
+  KLAYBNB: {
+    symbol: "KLAYBNB",
+    baseAsset: "KLAY",
+    quoteAsset: "BNB",
+  },
+  KLAYBUSD: {
+    symbol: "KLAYBUSD",
+    baseAsset: "KLAY",
+    quoteAsset: "BUSD",
+  },
+  KLAYUSDT: {
+    symbol: "KLAYUSDT",
+    baseAsset: "KLAY",
+    quoteAsset: "USDT",
+  },
+  RUNEEUR: {
+    symbol: "RUNEEUR",
+    baseAsset: "RUNE",
+    quoteAsset: "EUR",
+  },
+  MATICAUD: {
+    symbol: "MATICAUD",
+    baseAsset: "MATIC",
+    quoteAsset: "AUD",
+  },
+  DOTRUB: {
+    symbol: "DOTRUB",
+    baseAsset: "DOT",
+    quoteAsset: "RUB",
+  },
+  UTKBUSD: {
+    symbol: "UTKBUSD",
+    baseAsset: "UTK",
+    quoteAsset: "BUSD",
+  },
+  IOTXBUSD: {
+    symbol: "IOTXBUSD",
+    baseAsset: "IOTX",
+    quoteAsset: "BUSD",
+  },
+  PHAUSDT: {
+    symbol: "PHAUSDT",
+    baseAsset: "PHA",
+    quoteAsset: "USDT",
+  },
+  SOLRUB: {
+    symbol: "SOLRUB",
+    baseAsset: "SOL",
+    quoteAsset: "RUB",
+  },
+  RUNEAUD: {
+    symbol: "RUNEAUD",
+    baseAsset: "RUNE",
+    quoteAsset: "AUD",
+  },
+  BUSDUAH: {
+    symbol: "BUSDUAH",
+    baseAsset: "BUSD",
+    quoteAsset: "UAH",
+  },
+  BONDBTC: {
+    symbol: "BONDBTC",
+    baseAsset: "BOND",
+    quoteAsset: "BTC",
+  },
+  BONDBNB: {
+    symbol: "BONDBNB",
+    baseAsset: "BOND",
+    quoteAsset: "BNB",
+  },
+  BONDBUSD: {
+    symbol: "BONDBUSD",
+    baseAsset: "BOND",
+    quoteAsset: "BUSD",
+  },
+  BONDUSDT: {
+    symbol: "BONDUSDT",
+    baseAsset: "BOND",
+    quoteAsset: "USDT",
+  },
+  MLNBTC: {
+    symbol: "MLNBTC",
+    baseAsset: "MLN",
+    quoteAsset: "BTC",
+  },
+  MLNBNB: {
+    symbol: "MLNBNB",
+    baseAsset: "MLN",
+    quoteAsset: "BNB",
+  },
+  MLNBUSD: {
+    symbol: "MLNBUSD",
+    baseAsset: "MLN",
+    quoteAsset: "BUSD",
+  },
+  MLNUSDT: {
+    symbol: "MLNUSDT",
+    baseAsset: "MLN",
+    quoteAsset: "USDT",
+  },
+  GRTTRY: {
+    symbol: "GRTTRY",
+    baseAsset: "GRT",
+    quoteAsset: "TRY",
+  },
+  CAKEBRL: {
+    symbol: "CAKEBRL",
+    baseAsset: "CAKE",
+    quoteAsset: "BRL",
+  },
+  ICPRUB: {
+    symbol: "ICPRUB",
+    baseAsset: "ICP",
+    quoteAsset: "RUB",
+  },
+  DOTAUD: {
+    symbol: "DOTAUD",
+    baseAsset: "DOT",
+    quoteAsset: "AUD",
+  },
+  AAVEBRL: {
+    symbol: "AAVEBRL",
+    baseAsset: "AAVE",
+    quoteAsset: "BRL",
+  },
+  EOSAUD: {
+    symbol: "EOSAUD",
+    baseAsset: "EOS",
+    quoteAsset: "AUD",
+  },
+  DEXEUSDT: {
+    symbol: "DEXEUSDT",
+    baseAsset: "DEXE",
+    quoteAsset: "USDT",
+  },
+  LTOBUSD: {
+    symbol: "LTOBUSD",
+    baseAsset: "LTO",
+    quoteAsset: "BUSD",
+  },
+  ADXBUSD: {
+    symbol: "ADXBUSD",
+    baseAsset: "ADX",
+    quoteAsset: "BUSD",
+  },
+  QUICKBTC: {
+    symbol: "QUICKBTC",
+    baseAsset: "QUICK",
+    quoteAsset: "BTC",
+  },
+  QUICKBNB: {
+    symbol: "QUICKBNB",
+    baseAsset: "QUICK",
+    quoteAsset: "BNB",
+  },
+  QUICKBUSD: {
+    symbol: "QUICKBUSD",
+    baseAsset: "QUICK",
+    quoteAsset: "BUSD",
+  },
+  C98USDT: {
+    symbol: "C98USDT",
+    baseAsset: "C98",
+    quoteAsset: "USDT",
+  },
+  C98BUSD: {
+    symbol: "C98BUSD",
+    baseAsset: "C98",
+    quoteAsset: "BUSD",
+  },
+  C98BNB: {
+    symbol: "C98BNB",
+    baseAsset: "C98",
+    quoteAsset: "BNB",
+  },
+  C98BTC: {
+    symbol: "C98BTC",
+    baseAsset: "C98",
+    quoteAsset: "BTC",
+  },
+  CLVBTC: {
+    symbol: "CLVBTC",
+    baseAsset: "CLV",
+    quoteAsset: "BTC",
+  },
+  CLVBNB: {
+    symbol: "CLVBNB",
+    baseAsset: "CLV",
+    quoteAsset: "BNB",
+  },
+  CLVBUSD: {
+    symbol: "CLVBUSD",
+    baseAsset: "CLV",
+    quoteAsset: "BUSD",
+  },
+  CLVUSDT: {
+    symbol: "CLVUSDT",
+    baseAsset: "CLV",
+    quoteAsset: "USDT",
+  },
+  QNTBTC: {
+    symbol: "QNTBTC",
+    baseAsset: "QNT",
+    quoteAsset: "BTC",
+  },
+  QNTBNB: {
+    symbol: "QNTBNB",
+    baseAsset: "QNT",
+    quoteAsset: "BNB",
+  },
+  QNTBUSD: {
+    symbol: "QNTBUSD",
+    baseAsset: "QNT",
+    quoteAsset: "BUSD",
+  },
+  QNTUSDT: {
+    symbol: "QNTUSDT",
+    baseAsset: "QNT",
+    quoteAsset: "USDT",
+  },
+  FLOWBTC: {
+    symbol: "FLOWBTC",
+    baseAsset: "FLOW",
+    quoteAsset: "BTC",
+  },
+  FLOWBNB: {
+    symbol: "FLOWBNB",
+    baseAsset: "FLOW",
+    quoteAsset: "BNB",
+  },
+  FLOWBUSD: {
+    symbol: "FLOWBUSD",
+    baseAsset: "FLOW",
+    quoteAsset: "BUSD",
+  },
+  FLOWUSDT: {
+    symbol: "FLOWUSDT",
+    baseAsset: "FLOW",
+    quoteAsset: "USDT",
+  },
+  XECBUSD: {
+    symbol: "XECBUSD",
+    baseAsset: "XEC",
+    quoteAsset: "BUSD",
+  },
+  AXSBRL: {
+    symbol: "AXSBRL",
+    baseAsset: "AXS",
+    quoteAsset: "BRL",
+  },
+  AXSAUD: {
+    symbol: "AXSAUD",
+    baseAsset: "AXS",
+    quoteAsset: "AUD",
+  },
+  TVKUSDT: {
+    symbol: "TVKUSDT",
+    baseAsset: "TVK",
+    quoteAsset: "USDT",
+  },
+  MINABTC: {
+    symbol: "MINABTC",
+    baseAsset: "MINA",
+    quoteAsset: "BTC",
+  },
+  MINABNB: {
+    symbol: "MINABNB",
+    baseAsset: "MINA",
+    quoteAsset: "BNB",
+  },
+  MINABUSD: {
+    symbol: "MINABUSD",
+    baseAsset: "MINA",
+    quoteAsset: "BUSD",
+  },
+  MINAUSDT: {
+    symbol: "MINAUSDT",
+    baseAsset: "MINA",
+    quoteAsset: "USDT",
+  },
+  RAYBNB: {
+    symbol: "RAYBNB",
+    baseAsset: "RAY",
+    quoteAsset: "BNB",
+  },
+  RAYBUSD: {
+    symbol: "RAYBUSD",
+    baseAsset: "RAY",
+    quoteAsset: "BUSD",
+  },
+  RAYUSDT: {
+    symbol: "RAYUSDT",
+    baseAsset: "RAY",
+    quoteAsset: "USDT",
+  },
+  FARMBTC: {
+    symbol: "FARMBTC",
+    baseAsset: "FARM",
+    quoteAsset: "BTC",
+  },
+  FARMBNB: {
+    symbol: "FARMBNB",
+    baseAsset: "FARM",
+    quoteAsset: "BNB",
+  },
+  FARMBUSD: {
+    symbol: "FARMBUSD",
+    baseAsset: "FARM",
+    quoteAsset: "BUSD",
+  },
+  FARMUSDT: {
+    symbol: "FARMUSDT",
+    baseAsset: "FARM",
+    quoteAsset: "USDT",
+  },
+  ALPACABTC: {
+    symbol: "ALPACABTC",
+    baseAsset: "ALPACA",
+    quoteAsset: "BTC",
+  },
+  ALPACABNB: {
+    symbol: "ALPACABNB",
+    baseAsset: "ALPACA",
+    quoteAsset: "BNB",
+  },
+  ALPACABUSD: {
+    symbol: "ALPACABUSD",
+    baseAsset: "ALPACA",
+    quoteAsset: "BUSD",
+  },
+  ALPACAUSDT: {
+    symbol: "ALPACAUSDT",
+    baseAsset: "ALPACA",
+    quoteAsset: "USDT",
+  },
+  TLMTRY: {
+    symbol: "TLMTRY",
+    baseAsset: "TLM",
+    quoteAsset: "TRY",
+  },
+  QUICKUSDT: {
+    symbol: "QUICKUSDT",
+    baseAsset: "QUICK",
+    quoteAsset: "USDT",
+  },
+  ORNBUSD: {
+    symbol: "ORNBUSD",
+    baseAsset: "ORN",
+    quoteAsset: "BUSD",
+  },
+  MBOXBTC: {
+    symbol: "MBOXBTC",
+    baseAsset: "MBOX",
+    quoteAsset: "BTC",
+  },
+  MBOXBNB: {
+    symbol: "MBOXBNB",
+    baseAsset: "MBOX",
+    quoteAsset: "BNB",
+  },
+  MBOXBUSD: {
+    symbol: "MBOXBUSD",
+    baseAsset: "MBOX",
+    quoteAsset: "BUSD",
+  },
+  MBOXUSDT: {
+    symbol: "MBOXUSDT",
+    baseAsset: "MBOX",
+    quoteAsset: "USDT",
+  },
+  VGXBTC: {
+    symbol: "VGXBTC",
+    baseAsset: "VGX",
+    quoteAsset: "BTC",
+  },
+  VGXETH: {
+    symbol: "VGXETH",
+    baseAsset: "VGX",
+    quoteAsset: "ETH",
+  },
+  FORUSDT: {
+    symbol: "FORUSDT",
+    baseAsset: "FOR",
+    quoteAsset: "USDT",
+  },
+  REQUSDT: {
+    symbol: "REQUSDT",
+    baseAsset: "REQ",
+    quoteAsset: "USDT",
+  },
+  GHSTUSDT: {
+    symbol: "GHSTUSDT",
+    baseAsset: "GHST",
+    quoteAsset: "USDT",
+  },
+  TRURUB: {
+    symbol: "TRURUB",
+    baseAsset: "TRU",
+    quoteAsset: "RUB",
+  },
+  FISBRL: {
+    symbol: "FISBRL",
+    baseAsset: "FIS",
+    quoteAsset: "BRL",
+  },
+  WAXPUSDT: {
+    symbol: "WAXPUSDT",
+    baseAsset: "WAXP",
+    quoteAsset: "USDT",
+  },
+  WAXPBUSD: {
+    symbol: "WAXPBUSD",
+    baseAsset: "WAXP",
+    quoteAsset: "BUSD",
+  },
+  WAXPBNB: {
+    symbol: "WAXPBNB",
+    baseAsset: "WAXP",
+    quoteAsset: "BNB",
+  },
+  WAXPBTC: {
+    symbol: "WAXPBTC",
+    baseAsset: "WAXP",
+    quoteAsset: "BTC",
+  },
+  TRIBEBTC: {
+    symbol: "TRIBEBTC",
+    baseAsset: "TRIBE",
+    quoteAsset: "BTC",
+  },
+  TRIBEBNB: {
+    symbol: "TRIBEBNB",
+    baseAsset: "TRIBE",
+    quoteAsset: "BNB",
+  },
+  TRIBEBUSD: {
+    symbol: "TRIBEBUSD",
+    baseAsset: "TRIBE",
+    quoteAsset: "BUSD",
+  },
+  TRIBEUSDT: {
+    symbol: "TRIBEUSDT",
+    baseAsset: "TRIBE",
+    quoteAsset: "USDT",
+  },
+  GNOUSDT: {
+    symbol: "GNOUSDT",
+    baseAsset: "GNO",
+    quoteAsset: "USDT",
+  },
+  GNOBUSD: {
+    symbol: "GNOBUSD",
+    baseAsset: "GNO",
+    quoteAsset: "BUSD",
+  },
+  GNOBNB: {
+    symbol: "GNOBNB",
+    baseAsset: "GNO",
+    quoteAsset: "BNB",
+  },
+  GNOBTC: {
+    symbol: "GNOBTC",
+    baseAsset: "GNO",
+    quoteAsset: "BTC",
+  },
+  ARPATRY: {
+    symbol: "ARPATRY",
+    baseAsset: "ARPA",
+    quoteAsset: "TRY",
+  },
+  PROMBTC: {
+    symbol: "PROMBTC",
+    baseAsset: "PROM",
+    quoteAsset: "BTC",
+  },
+  MTLBUSD: {
+    symbol: "MTLBUSD",
+    baseAsset: "MTL",
+    quoteAsset: "BUSD",
+  },
+  OGNBUSD: {
+    symbol: "OGNBUSD",
+    baseAsset: "OGN",
+    quoteAsset: "BUSD",
+  },
+  XECUSDT: {
+    symbol: "XECUSDT",
+    baseAsset: "XEC",
+    quoteAsset: "USDT",
+  },
+  C98BRL: {
+    symbol: "C98BRL",
+    baseAsset: "C98",
+    quoteAsset: "BRL",
+  },
+  SOLAUD: {
+    symbol: "SOLAUD",
+    baseAsset: "SOL",
+    quoteAsset: "AUD",
+  },
+  SUSHIBIDR: {
+    symbol: "SUSHIBIDR",
+    baseAsset: "SUSHI",
+    quoteAsset: "BIDR",
+  },
+  XRPBIDR: {
+    symbol: "XRPBIDR",
+    baseAsset: "XRP",
+    quoteAsset: "BIDR",
+  },
+  POLYBUSD: {
+    symbol: "POLYBUSD",
+    baseAsset: "POLY",
+    quoteAsset: "BUSD",
+  },
+  ELFUSDT: {
+    symbol: "ELFUSDT",
+    baseAsset: "ELF",
+    quoteAsset: "USDT",
+  },
+  DYDXUSDT: {
+    symbol: "DYDXUSDT",
+    baseAsset: "DYDX",
+    quoteAsset: "USDT",
+  },
+  DYDXBUSD: {
+    symbol: "DYDXBUSD",
+    baseAsset: "DYDX",
+    quoteAsset: "BUSD",
+  },
+  DYDXBNB: {
+    symbol: "DYDXBNB",
+    baseAsset: "DYDX",
+    quoteAsset: "BNB",
+  },
+  DYDXBTC: {
+    symbol: "DYDXBTC",
+    baseAsset: "DYDX",
+    quoteAsset: "BTC",
+  },
+  ELFBUSD: {
+    symbol: "ELFBUSD",
+    baseAsset: "ELF",
+    quoteAsset: "BUSD",
+  },
+  POLYUSDT: {
+    symbol: "POLYUSDT",
+    baseAsset: "POLY",
+    quoteAsset: "USDT",
+  },
+  IDEXUSDT: {
+    symbol: "IDEXUSDT",
+    baseAsset: "IDEX",
+    quoteAsset: "USDT",
+  },
+  VIDTUSDT: {
+    symbol: "VIDTUSDT",
+    baseAsset: "VIDT",
+    quoteAsset: "USDT",
+  },
+  SOLBIDR: {
+    symbol: "SOLBIDR",
+    baseAsset: "SOL",
+    quoteAsset: "BIDR",
+  },
+  AXSBIDR: {
+    symbol: "AXSBIDR",
+    baseAsset: "AXS",
+    quoteAsset: "BIDR",
+  },
+  BTCUSDP: {
+    symbol: "BTCUSDP",
+    baseAsset: "BTC",
+    quoteAsset: "USDP",
+  },
+  ETHUSDP: {
+    symbol: "ETHUSDP",
+    baseAsset: "ETH",
+    quoteAsset: "USDP",
+  },
+  BNBUSDP: {
+    symbol: "BNBUSDP",
+    baseAsset: "BNB",
+    quoteAsset: "USDP",
+  },
+  USDPBUSD: {
+    symbol: "USDPBUSD",
+    baseAsset: "USDP",
+    quoteAsset: "BUSD",
+  },
+  USDPUSDT: {
+    symbol: "USDPUSDT",
+    baseAsset: "USDP",
+    quoteAsset: "USDT",
+  },
+  GALAUSDT: {
+    symbol: "GALAUSDT",
+    baseAsset: "GALA",
+    quoteAsset: "USDT",
+  },
+  GALABUSD: {
+    symbol: "GALABUSD",
+    baseAsset: "GALA",
+    quoteAsset: "BUSD",
+  },
+  GALABNB: {
+    symbol: "GALABNB",
+    baseAsset: "GALA",
+    quoteAsset: "BNB",
+  },
+  GALABTC: {
+    symbol: "GALABTC",
+    baseAsset: "GALA",
+    quoteAsset: "BTC",
+  },
+  FTMBIDR: {
+    symbol: "FTMBIDR",
+    baseAsset: "FTM",
+    quoteAsset: "BIDR",
+  },
+  ALGOBIDR: {
+    symbol: "ALGOBIDR",
+    baseAsset: "ALGO",
+    quoteAsset: "BIDR",
+  },
+  CAKEAUD: {
+    symbol: "CAKEAUD",
+    baseAsset: "CAKE",
+    quoteAsset: "AUD",
+  },
+  KSMAUD: {
+    symbol: "KSMAUD",
+    baseAsset: "KSM",
+    quoteAsset: "AUD",
+  },
+  WAVESRUB: {
+    symbol: "WAVESRUB",
+    baseAsset: "WAVES",
+    quoteAsset: "RUB",
+  },
+  SUNBUSD: {
+    symbol: "SUNBUSD",
+    baseAsset: "SUN",
+    quoteAsset: "BUSD",
+  },
+  ILVUSDT: {
+    symbol: "ILVUSDT",
+    baseAsset: "ILV",
+    quoteAsset: "USDT",
+  },
+  ILVBUSD: {
+    symbol: "ILVBUSD",
+    baseAsset: "ILV",
+    quoteAsset: "BUSD",
+  },
+  ILVBNB: {
+    symbol: "ILVBNB",
+    baseAsset: "ILV",
+    quoteAsset: "BNB",
+  },
+  ILVBTC: {
+    symbol: "ILVBTC",
+    baseAsset: "ILV",
+    quoteAsset: "BTC",
+  },
+  RENBUSD: {
+    symbol: "RENBUSD",
+    baseAsset: "REN",
+    quoteAsset: "BUSD",
+  },
+  YGGUSDT: {
+    symbol: "YGGUSDT",
+    baseAsset: "YGG",
+    quoteAsset: "USDT",
+  },
+  YGGBUSD: {
+    symbol: "YGGBUSD",
+    baseAsset: "YGG",
+    quoteAsset: "BUSD",
+  },
+  YGGBNB: {
+    symbol: "YGGBNB",
+    baseAsset: "YGG",
+    quoteAsset: "BNB",
+  },
+  YGGBTC: {
+    symbol: "YGGBTC",
+    baseAsset: "YGG",
+    quoteAsset: "BTC",
+  },
+  STXBUSD: {
+    symbol: "STXBUSD",
+    baseAsset: "STX",
+    quoteAsset: "BUSD",
+  },
+  SYSUSDT: {
+    symbol: "SYSUSDT",
+    baseAsset: "SYS",
+    quoteAsset: "USDT",
+  },
+  DFUSDT: {
+    symbol: "DFUSDT",
+    baseAsset: "DF",
+    quoteAsset: "USDT",
+  },
+  SOLUSDC: {
+    symbol: "SOLUSDC",
+    baseAsset: "SOL",
+    quoteAsset: "USDC",
+  },
+  ARPARUB: {
+    symbol: "ARPARUB",
+    baseAsset: "ARPA",
+    quoteAsset: "RUB",
+  },
+  LTCUAH: {
+    symbol: "LTCUAH",
+    baseAsset: "LTC",
+    quoteAsset: "UAH",
+  },
+  FETBUSD: {
+    symbol: "FETBUSD",
+    baseAsset: "FET",
+    quoteAsset: "BUSD",
+  },
+  ARPABUSD: {
+    symbol: "ARPABUSD",
+    baseAsset: "ARPA",
+    quoteAsset: "BUSD",
+  },
+  LSKBUSD: {
+    symbol: "LSKBUSD",
+    baseAsset: "LSK",
+    quoteAsset: "BUSD",
+  },
+  AVAXBIDR: {
+    symbol: "AVAXBIDR",
+    baseAsset: "AVAX",
+    quoteAsset: "BIDR",
+  },
+  ALICEBIDR: {
+    symbol: "ALICEBIDR",
+    baseAsset: "ALICE",
+    quoteAsset: "BIDR",
+  },
+  FIDAUSDT: {
+    symbol: "FIDAUSDT",
+    baseAsset: "FIDA",
+    quoteAsset: "USDT",
+  },
+  FIDABUSD: {
+    symbol: "FIDABUSD",
+    baseAsset: "FIDA",
+    quoteAsset: "BUSD",
+  },
+  FIDABNB: {
+    symbol: "FIDABNB",
+    baseAsset: "FIDA",
+    quoteAsset: "BNB",
+  },
+  FIDABTC: {
+    symbol: "FIDABTC",
+    baseAsset: "FIDA",
+    quoteAsset: "BTC",
+  },
+  DENTBUSD: {
+    symbol: "DENTBUSD",
+    baseAsset: "DENT",
+    quoteAsset: "BUSD",
+  },
+  FRONTUSDT: {
+    symbol: "FRONTUSDT",
+    baseAsset: "FRONT",
+    quoteAsset: "USDT",
+  },
+  CVPUSDT: {
+    symbol: "CVPUSDT",
+    baseAsset: "CVP",
+    quoteAsset: "USDT",
+  },
+} as const
+
+export const BINANCE_SUPPORTED_FIATS = [
+  "GBP",
+  "TRY",
+  "EUR",
+  "KZT",
+  "AUD",
+  "BRL",
+  "HKD",
+  "PEN",
+  "RUB",
+  "UAH",
+  "UGX",
+  "PHP",
+  "USD",
+]
+
+export type BinanceSupportedFiat = typeof BINANCE_SUPPORTED_FIATS[number]
+
+export type BinanceMarket = keyof typeof BINANCE_MARKETS
+
+export type BinanceSymbol =
+  typeof BINANCE_MARKETS[keyof typeof BINANCE_MARKETS][
+    | "baseAsset"
+    | "quoteAsset"]


### PR DESCRIPTION
Binance exports a different schema for spot trade
transactions and "buy bitcoin with fiat" transactions,
so they have to be separately handled.

My guess is UI will have to detect the format and
use the correct implementation based on the header.

Also, the exported trades do not have identifiers, but the buy/sell transactions do :)