### PR TITLE
Change Temporal to date-fns

### DIFF
--- a/app/components/AddRowForm.tsx
+++ b/app/components/AddRowForm.tsx
@@ -6,13 +6,12 @@ import React, {
   useState,
 } from "react";
 import { Ledger, LedgerItem } from "@fifo/ledger";
-import { Temporal } from "proposal-temporal";
 import s from "../styles/AddRowForm.module.scss";
 import { insertEvent, useAppDispatch } from "./store";
 import { getPriceAt, useCoinSymbolsQuery } from "./coinbase";
 
 const DEFAULT_ITEM = {
-  date: Temporal.now.plainDate("iso8601"),
+  timestamp: Date.now(),
   from: { amount: 1000, symbol: "EUR" },
   to: { amount: 1, symbol: "BTC" },
   fee: { amount: 0, symbol: "EUR", unitPriceEur: 1 },
@@ -27,7 +26,10 @@ const autoFillUniPriceIfMissing = async (ledgerItem: LedgerItem) => {
       ...ledgerItem,
       from: {
         ...ledgerItem.from,
-        unitPriceEur: await getPriceAt(ledgerItem.date, ledgerItem.from.symbol),
+        unitPriceEur: await getPriceAt(
+          ledgerItem.timestamp,
+          ledgerItem.from.symbol
+        ),
       },
     };
   } catch (e) {
@@ -36,7 +38,10 @@ const autoFillUniPriceIfMissing = async (ledgerItem: LedgerItem) => {
         ...ledgerItem,
         to: {
           ...ledgerItem.to,
-          unitPriceEur: await getPriceAt(ledgerItem.date, ledgerItem.to.symbol),
+          unitPriceEur: await getPriceAt(
+            ledgerItem.timestamp,
+            ledgerItem.to.symbol
+          ),
         },
       };
     } catch (e) {}
@@ -95,8 +100,8 @@ function AddRowForm({
             <div>
               <input
                 className={s.dateInput}
-                key={data.date.toLocaleString("fi")}
-                defaultValue={data.date.toLocaleString("fi")}
+                key={data.timestamp}
+                defaultValue={new Date(data.timestamp).toLocaleDateString("fi")}
                 pattern="^\d{1,2}\.\d{1,2}\.\d{4}$"
                 required
                 onBlur={(e) => {
@@ -106,7 +111,7 @@ function AddRowForm({
                       .map((v) => parseInt(v, 10));
                     setData({
                       ...data,
-                      date: Temporal.PlainDate.from({ day, month, year }),
+                      timestamp: new Date(year, month - 1, day).getTime(),
                     });
                   }
                 }}
@@ -264,7 +269,7 @@ function AddRowForm({
 }
 
 const withErrorBoundary = <P extends {}>(
-  Component: React.ComponentType<P>
+  Component: React.FunctionComponent<P>
 ): React.FC<P> => {
   function WithErrorBoundary(props) {
     return (

--- a/app/components/EntryRow.tsx
+++ b/app/components/EntryRow.tsx
@@ -84,8 +84,13 @@ function ItemRow({
   return (
     <tr>
       <td>
-        <a href={linkTo ? `#${item.id}` : undefined} title={item.id}>
-          {item.date.toLocaleString("fi")}
+        <a
+          href={linkTo ? `#${item.id}` : undefined}
+          title={`${item.id} / ${new Date(item.timestamp).toLocaleString(
+            "fi"
+          )}`}
+        >
+          {new Date(item.timestamp).toLocaleDateString("fi")}
         </a>
       </td>
       <td>

--- a/app/components/app-state.ts
+++ b/app/components/app-state.ts
@@ -1,10 +1,9 @@
 import { Ledger, LedgerItem, sortLedger } from "@fifo/ledger";
 import { readCsv } from "@fifo/csv-reader";
 import { useEffect } from "react";
-import { Temporal } from "proposal-temporal";
 
-export const toCacheKey = (symbol: string, date: Temporal.PlainDate) =>
-  [symbol, date.toString({ calendarName: "never" })].join("-");
+export const toCacheKey = (symbol: string, timestamp: number) =>
+  [symbol, timestamp].join("-");
 type PrefilledEurValues = { [symbolDateKey: string]: number };
 type ImportAppStateItem = {
   type: "importCoinbaseCsv";
@@ -34,13 +33,17 @@ const applyPrefilledValues = (
       ...ledgerItem.from,
       unitPriceEur:
         ledgerItem.from.unitPriceEur ??
-        prefilledEurValues[toCacheKey(ledgerItem.from.symbol, ledgerItem.date)],
+        prefilledEurValues[
+          toCacheKey(ledgerItem.from.symbol, ledgerItem.timestamp)
+        ],
     },
     to: {
       ...ledgerItem.to,
       unitPriceEur:
         ledgerItem.to.unitPriceEur ??
-        prefilledEurValues[toCacheKey(ledgerItem.to.symbol, ledgerItem.date)],
+        prefilledEurValues[
+          toCacheKey(ledgerItem.to.symbol, ledgerItem.timestamp)
+        ],
     },
   }));
 

--- a/app/components/coinbase.ts
+++ b/app/components/coinbase.ts
@@ -1,15 +1,14 @@
-import { Temporal } from "proposal-temporal";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import addDays from "date-fns/addDays";
 
-export const getPriceAt = async (date: Temporal.PlainDate, symbol: string) => {
+const toISOString = (timestamp: number | Date) =>
+  new Date(timestamp).toISOString();
+
+export const getPriceAt = async (timestamp: number, symbol: string) => {
   const result = await fetch(
-    `https://api.pro.coinbase.com/products/${symbol}-EUR/candles?start=${date.toString(
-      { calendarName: "never" }
-    )}Z00:00:00.00&end=${date
-      .add(Temporal.Duration.from({ days: 1 }))
-      .toString({
-        calendarName: "never",
-      })}Z00:00:00.00&granularity=86400`
+    `https://api.pro.coinbase.com/products/${symbol}-EUR/candles?start=${toISOString(
+      timestamp
+    )}&end=${toISOString(addDays(timestamp, 1))}&granularity=86400`
   ).then((res) => res.json());
   const first = result?.[0];
   if (!first) throw new Error("No result");

--- a/app/components/store.ts
+++ b/app/components/store.ts
@@ -87,8 +87,8 @@ function* autoFillCoinUnitPrices(action: PayloadAction<AppStateItem>) {
   const ledgerItems = readCsv(event.data);
   const prefilledEurValues = event.prefilledEurValues;
   for (const ledgerItem of ledgerItems) {
-    const fromKey = toCacheKey(ledgerItem.from.symbol, ledgerItem.date);
-    const toKey = toCacheKey(ledgerItem.to.symbol, ledgerItem.date);
+    const fromKey = toCacheKey(ledgerItem.from.symbol, ledgerItem.timestamp);
+    const toKey = toCacheKey(ledgerItem.to.symbol, ledgerItem.timestamp);
     if (fromKey in prefilledEurValues || toKey in prefilledEurValues) continue;
     if (
       ledgerItem.from.unitPriceEur ??
@@ -99,7 +99,7 @@ function* autoFillCoinUnitPrices(action: PayloadAction<AppStateItem>) {
     try {
       const filledFrom = yield call(
         getPriceAt,
-        ledgerItem.date,
+        ledgerItem.timestamp,
         ledgerItem.from.symbol
       );
       prefilledEurValues[fromKey] = filledFrom;
@@ -107,7 +107,7 @@ function* autoFillCoinUnitPrices(action: PayloadAction<AppStateItem>) {
       try {
         const filledTo = yield call(
           getPriceAt,
-          ledgerItem.date,
+          ledgerItem.timestamp,
           ledgerItem.from.symbol
         );
         prefilledEurValues[toKey] = filledTo;

--- a/app/package.json
+++ b/app/package.json
@@ -12,6 +12,7 @@
     "@reduxjs/toolkit": "^1.6.1",
     "@types/react-redux": "^7.1.18",
     "@types/wicg-file-system-access": "^2020.9.1",
+    "date-fns": "^2.28.0",
     "next": "11.0.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/app/pages/app.tsx
+++ b/app/pages/app.tsx
@@ -1,6 +1,5 @@
 import { v4 as uuid } from "uuid";
 import { calculateGains } from "@fifo/ledger";
-import { Temporal } from "proposal-temporal";
 import Header from "../components/Header";
 import { useSave } from "../components/use-save";
 import s from "../styles/App.module.scss";
@@ -16,6 +15,7 @@ import {
   isPrefillingSelector,
 } from "../components/store";
 import Loading from "../components/Loading";
+import getYear from "date-fns/getYear";
 
 export default function App() {
   usePreventUserLeaving();
@@ -26,7 +26,7 @@ export default function App() {
   }, [appState, onAutosave]);
   const { ledger, consumed } = useAppSelector(computedLedgerSelector);
   const uniqYears = Array.from(
-    new Set(ledger.map((item) => item.date.year))
+    new Set(ledger.map((item) => getYear(item.timestamp)))
   ).sort((a, b) => b - a);
   const [showEditRow, setShowEditRow] = useState<string | null>(null);
   const isPrefilling = useAppSelector(isPrefillingSelector);
@@ -58,8 +58,8 @@ export default function App() {
           </div>
           {uniqYears.map((year) => {
             const gains = calculateGains(
-              Temporal.PlainDate.from(`${year}-01-01`),
-              Temporal.PlainDate.from(`${year}-12-31`),
+              Date.parse(`${year}-01-01`),
+              Date.parse(`${year}-12-31`),
               ledger
             );
             const taxes = gains * 0.3;
@@ -78,7 +78,7 @@ export default function App() {
                   </dd>
                 </dl>
                 {ledger
-                  .filter((item) => item.date.year === year)
+                  .filter((item) => getYear(item.timestamp) === year)
                   .reverse()
                   .map((item) => (
                     <EntryRow

--- a/app/pages/load.tsx
+++ b/app/pages/load.tsx
@@ -1,4 +1,3 @@
-import { Temporal } from "proposal-temporal";
 import Header from "../components/Header";
 import Importer from "../components/Importer";
 import s from "../styles/Load.module.scss";
@@ -24,10 +23,7 @@ export default function CoinbaseImport() {
           onRead={async (file) => {
             // Todo: Handle autosave
             // Todo: Use parser like io-ts
-            const { items } = JSON.parse(
-              await file.text(),
-              reviveDates
-            ) as SaveData;
+            const { items } = JSON.parse(await file.text()) as SaveData;
             items.forEach((item) => dispatch(insertEvent(item)));
             router.push("/app");
           }}
@@ -44,8 +40,3 @@ export default function CoinbaseImport() {
     </>
   );
 }
-
-const reviveDates = (_, value: any) => {
-  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return Temporal.PlainDate.from(value);
-  return value;
-};

--- a/csv-reader/package.json
+++ b/csv-reader/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "@types/node": "^15.12.2",
     "ava": "^3.15.0",
-    "proposal-temporal": "^0.8.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.3.2",
     "@fifo/ledger": "*"

--- a/csv-reader/src/binance/binance.test.ts
+++ b/csv-reader/src/binance/binance.test.ts
@@ -1,6 +1,6 @@
 import test from "ava"
-import { Temporal } from "proposal-temporal"
 import { ExecutionContext } from "ava"
+import { utcDate } from "../testutils"
 import { readBuySellCsv, readTradeCsv } from "./binance"
 
 const BINANCE_TRADE_HEADER =
@@ -16,8 +16,7 @@ test("Empty report", (t) => {
 })
 
 test("TRADE: Sell BTC for USDT", (t) => {
-  eq(
-    t,
+  t.deepEqual(
     readTradeCsv(
       toCsv(
         BINANCE_TRADE_HEADER,
@@ -26,10 +25,10 @@ test("TRADE: Sell BTC for USDT", (t) => {
     ),
     [
       {
-        id: "binance_trade_2021-10-03T13:53:53",
-        date: Temporal.PlainDate.from("2021-10-03"),
-        from: { symbol: "BTC", amount: 0.00043 },
-        to: { symbol: "USDT", amount: 20.681538 },
+        id: "binance_trade_2021-10-03T13:53:53.000Z",
+        timestamp: Date.parse("2021-10-03T13:53:53.000Z"),
+        from: { symbol: "BTC", amount: 0.00043, unitPriceEur: undefined },
+        to: { symbol: "USDT", amount: 20.681538, unitPriceEur: undefined },
         fee: { symbol: "USDT", amount: 0.02068154 },
       },
     ]
@@ -37,8 +36,7 @@ test("TRADE: Sell BTC for USDT", (t) => {
 })
 
 test("TRADE: Sell LTC for BTC", (t) => {
-  eq(
-    t,
+  t.deepEqual(
     readTradeCsv(
       toCsv(
         BINANCE_TRADE_HEADER,
@@ -47,10 +45,10 @@ test("TRADE: Sell LTC for BTC", (t) => {
     ),
     [
       {
-        id: "binance_trade_2021-10-03T13:32:06",
-        date: Temporal.PlainDate.from("2021-10-03"),
-        from: { symbol: "LTC", amount: 5 },
-        to: { symbol: "BTC", amount: 0.0000539 },
+        id: "binance_trade_2021-10-03T13:32:06.000Z",
+        timestamp: Date.parse("2021-10-03T13:32:06.000Z"),
+        from: { symbol: "LTC", amount: 5, unitPriceEur: undefined },
+        to: { symbol: "BTC", amount: 0.0000539, unitPriceEur: undefined },
         fee: { symbol: "BTC", amount: 0.00000005 },
       },
     ]
@@ -58,8 +56,7 @@ test("TRADE: Sell LTC for BTC", (t) => {
 })
 
 test("TRADE: Buy LTC with BTC", (t) => {
-  eq(
-    t,
+  t.deepEqual(
     readTradeCsv(
       toCsv(
         BINANCE_TRADE_HEADER,
@@ -68,10 +65,10 @@ test("TRADE: Buy LTC with BTC", (t) => {
     ),
     [
       {
-        id: "binance_trade_2021-10-03T13:09:07",
-        date: Temporal.PlainDate.from("2021-10-03"),
-        from: { symbol: "BTC", amount: 0.000217 },
-        to: { symbol: "LTC", amount: 20 },
+        id: "binance_trade_2021-10-03T13:09:07.000Z",
+        timestamp: Date.parse("2021-10-03T13:09:07.000Z"),
+        from: { symbol: "BTC", amount: 0.000217, unitPriceEur: undefined },
+        to: { symbol: "LTC", amount: 20, unitPriceEur: undefined },
         fee: { symbol: "LTC", amount: 0.02 },
       },
     ]
@@ -79,8 +76,7 @@ test("TRADE: Buy LTC with BTC", (t) => {
 })
 
 test("BUY: Buy BTC with EUR", (t) => {
-  eq(
-    t,
+  t.deepEqual(
     readBuySellCsv(
       toCsv(
         BINANCE_BUYSELL_HEADER,
@@ -90,7 +86,7 @@ test("BUY: Buy BTC with EUR", (t) => {
     [
       {
         id: "binance_buysell_foobarbazidentifier",
-        date: Temporal.PlainDate.from("2021-10-03"),
+        timestamp: Date.parse("2021-10-03T11:31:19.000Z"),
         from: { symbol: "EUR", amount: 49.1 },
         to: { symbol: "BTC", amount: 0.00118984 },
         fee: { symbol: "EUR", amount: 0.0 },
@@ -98,9 +94,3 @@ test("BUY: Buy BTC with EUR", (t) => {
     ]
   )
 })
-
-export const eq = <T>(t: ExecutionContext<unknown>, left: T, right: T) =>
-  t.deepEqual(
-    JSON.parse(JSON.stringify(left)),
-    JSON.parse(JSON.stringify(right))
-  )

--- a/csv-reader/src/binance/binance.ts
+++ b/csv-reader/src/binance/binance.ts
@@ -1,4 +1,3 @@
-import { Temporal } from "proposal-temporal"
 import { Ledger, LedgerItem } from "@fifo/ledger"
 import * as B from "@fifo/csv-reader/src/binance/markets-symbols"
 
@@ -25,8 +24,8 @@ export function readTradeCsv(input: string): Ledger {
       const fromUnitPriceEur = row.type === "BUY" ? 1 : row.price
       const toUnitPriceEur = row.type === "BUY" ? row.price : 1
       return {
-        id: `binance_trade_${row.createdAt.toString()}`,
-        date: row.createdAt.toPlainDate(),
+        id: `binance_trade_${new Date(row.createdAt).toISOString()}`,
+        timestamp: row.createdAt,
         from: {
           symbol: fromSymbol,
           amount: fromAmount,
@@ -52,7 +51,7 @@ export function readBuySellCsv(input: string): Ledger {
       // TODO: omitting the unitPriceEurs from this since i'm unsure what's correct.
       return {
         id: `binance_buysell_${row.id}`,
-        date: row.createdAt.toPlainDate(),
+        timestamp: row.createdAt,
         from: {
           symbol: row.fromCoin,
           amount: row.fromAmount,
@@ -70,7 +69,7 @@ export function readBuySellCsv(input: string): Ledger {
 export function parseTradeRow(strRow: string[]) {
   const [dateUTC, market, type, price, amount, total, fee, feeCoin] = strRow
   return {
-    createdAt: Temporal.PlainDateTime.from(dateUTC),
+    createdAt: Date.parse(dateUTC + "Z"),
     market,
     type: type as "BUY" | "SELL",
     amount: parseFloat(amount),
@@ -99,7 +98,7 @@ export function parseBuySellRow(strRow: string[]) {
   const [fee, feeCoin] = fees.split(" ")
   return {
     id: transactionId,
-    createdAt: Temporal.PlainDateTime.from(dateUTC),
+    createdAt: Date.parse(dateUTC + "Z"),
     method,
     status,
     fromAmount: parseFloat(fromAmount),

--- a/csv-reader/src/coinbase.test.ts
+++ b/csv-reader/src/coinbase.test.ts
@@ -1,5 +1,4 @@
 import test from "ava"
-import { Temporal } from "proposal-temporal"
 import { readCsv } from "."
 
 const COINBASE_HEADER = `portfolio,trade id,product,side,created at,size,size unit,price,fee,total,price/fee/total unit`
@@ -21,7 +20,7 @@ test("Buy BTC with EUR", (t) => {
     [
       {
         id: "coinbase_12345",
-        date: Temporal.PlainDate.from("2021-01-01"),
+        timestamp: utcDate("2021-01-01"),
         from: { symbol: "EUR", unitPriceEur: 1, amount: 10 },
         to: { symbol: "BTC", amount: 0.001, unitPriceEur: 10_000 },
         fee: { symbol: "EUR", amount: 0.1 },
@@ -41,7 +40,7 @@ test("Sell BTC to EUR", (t) => {
     [
       {
         id: "coinbase_1234",
-        date: Temporal.PlainDate.from("2021-01-01"),
+        timestamp: utcDate("2021-01-01"),
         from: { symbol: "BTC", amount: 0.001, unitPriceEur: 10_000 },
         to: { symbol: "EUR", unitPriceEur: 1, amount: 10 },
         fee: { symbol: "EUR", amount: 0.1 },
@@ -61,7 +60,7 @@ test("Sell ETH to ADA", (t) => {
     [
       {
         id: "coinbase_1234",
-        date: Temporal.PlainDate.from("2021-01-01"),
+        timestamp: utcDate("2021-01-01"),
         from: { symbol: "ETH", amount: 0.001998945 },
         to: { symbol: "ADA", amount: 3.25 },
         fee: { symbol: "ETH", amount: 0.000009945 },
@@ -81,7 +80,7 @@ test("Sell ADA to ETH", (t) => {
     [
       {
         id: "coinbase_1234",
-        date: Temporal.PlainDate.from("2021-01-01"),
+        timestamp: utcDate("2021-01-01"),
         from: { symbol: "ADA", amount: 0.001998945 },
         to: { symbol: "ETH", amount: 3.25 },
         fee: { symbol: "ETH", amount: 0.000009945 },
@@ -91,6 +90,7 @@ test("Sell ADA to ETH", (t) => {
 })
 
 import { ExecutionContext } from "ava"
+import { utcDate } from "./testutils"
 
 export const eq = <T>(t: ExecutionContext<unknown>, left: T, right: T) =>
   t.deepEqual(

--- a/csv-reader/src/index.ts
+++ b/csv-reader/src/index.ts
@@ -1,4 +1,3 @@
-import { Temporal } from "proposal-temporal"
 import { Ledger, LedgerItem } from "@fifo/ledger"
 
 export function readCsv(input: string): Ledger {
@@ -17,7 +16,7 @@ export function readCsv(input: string): Ledger {
       const toUnitPriceEur = row.side === "BUY" ? row.price : 1
       return {
         id: `coinbase_${row.tradeId}`,
-        date: row.createdAt,
+        timestamp: row.createdAt,
         from: {
           symbol: fromSymbol,
           amount: fromAmount,
@@ -54,7 +53,7 @@ function parseRow(strRow: string[]) {
     tradeId: parseInt(tradeId, 10),
     product,
     side: side as "BUY" | "SELL",
-    createdAt: Temporal.PlainDate.from(createdAt.slice(0, 10)),
+    createdAt: Date.parse(createdAt),
     size: parseFloat(size),
     sizeUnit,
     price: parseFloat(price),

--- a/csv-reader/src/testutils.ts
+++ b/csv-reader/src/testutils.ts
@@ -1,0 +1,1 @@
+export const utcDate = (date: string) => Date.parse(date)

--- a/ledger/package.json
+++ b/ledger/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@types/node": "^15.12.2",
     "ava": "^3.15.0",
-    "proposal-temporal": "^0.8.0",
+    "date-fns": "^2.28.0",
     "ts-node": "^10.0.0",
     "typescript": "^4.3.2"
   },

--- a/ledger/src/example.verohallinto-fifo-laskuri.test.ts
+++ b/ledger/src/example.verohallinto-fifo-laskuri.test.ts
@@ -1,6 +1,6 @@
 import test from "ava"
-import { Temporal } from "proposal-temporal"
 import { calculateGains, Ledger } from "."
+import { utcDate } from "./testutils"
 
 // Sourced from:
 // https://www.vero.fi/tietoa-verohallinnosta/yhteystiedot-ja-asiointi/asioi-verkossa/verohallinnon_laskuri/fifo-laskuri/
@@ -9,31 +9,31 @@ import { calculateGains, Ledger } from "."
 const initialLedger: Ledger = [
   {
     id: "1",
-    date: Temporal.PlainDate.from("2016-01-01"),
+    timestamp: utcDate("2016-01-01"),
     from: { symbol: "EUR", amount: 1_000, unitPriceEur: 1 },
     to: { symbol: "BTC", unitPriceEur: 1_000, amount: 1 },
   },
   {
     id: "2",
-    date: Temporal.PlainDate.from("2016-01-02"),
+    timestamp: utcDate("2016-01-02"),
     from: { symbol: "EUR", amount: 1_500, unitPriceEur: 1 },
     to: { symbol: "BTC", unitPriceEur: 1_500, amount: 1 },
   },
   {
     id: "3",
-    date: Temporal.PlainDate.from("2016-11-01"),
+    timestamp: utcDate("2016-11-01"),
     from: { symbol: "BTC", amount: 0.5, unitPriceEur: 2_000 },
     to: { symbol: "EUR", amount: 1_000, unitPriceEur: 1 },
   },
   {
     id: "4",
-    date: Temporal.PlainDate.from("2017-12-01"),
+    timestamp: utcDate("2017-12-01"),
     from: { symbol: "BTC", amount: 1, unitPriceEur: 10_000 },
     to: { symbol: "EUR", amount: 10_000, unitPriceEur: 1 },
   },
   {
     id: "5",
-    date: Temporal.PlainDate.from("2017-12-30"),
+    timestamp: utcDate("2017-12-30"),
     from: { symbol: "BTC", amount: 0.3, unitPriceEur: 500 },
     to: { symbol: "EUR", amount: 150, unitPriceEur: 1 },
   },
@@ -41,19 +41,11 @@ const initialLedger: Ledger = [
 
 test("'Ohje laskurin käyttämiseen' -tab example", (t) => {
   t.is(
-    calculateGains(
-      Temporal.PlainDate.from("2015-12-31"),
-      Temporal.PlainDate.from("2016-12-31"),
-      initialLedger
-    ),
+    calculateGains(utcDate("2015-12-31"), utcDate("2016-12-31"), initialLedger),
     500
   )
   t.is(
-    calculateGains(
-      Temporal.PlainDate.from("2016-12-31"),
-      Temporal.PlainDate.from("2017-12-31"),
-      initialLedger
-    ),
+    calculateGains(utcDate("2016-12-31"), utcDate("2017-12-31"), initialLedger),
     7700
   )
 })

--- a/ledger/src/example1.test.ts
+++ b/ledger/src/example1.test.ts
@@ -1,7 +1,6 @@
 import test from "ava"
-import { Temporal } from "proposal-temporal"
 import { calculateGains, Ledger } from "."
-import { eq } from "./testutils"
+import { eq, utcDate } from "./testutils"
 import { toComputedLedger } from "./to-computed-ledger"
 
 // Sourced from:
@@ -10,19 +9,19 @@ import { toComputedLedger } from "./to-computed-ledger"
 const initialLedger: Ledger = [
   {
     id: "1",
-    date: Temporal.PlainDate.from("2017-01-01"),
+    timestamp: utcDate("2017-01-01"),
     from: { symbol: "EUR", amount: 500, unitPriceEur: 1 },
     to: { symbol: "A", unitPriceEur: 5, amount: 100 },
   },
   {
     id: "2",
-    date: Temporal.PlainDate.from("2017-02-01"),
+    timestamp: utcDate("2017-02-01"),
     from: { symbol: "EUR", amount: 1000, unitPriceEur: 1 },
     to: { symbol: "A", unitPriceEur: 10, amount: 100 },
   },
   {
     id: "3",
-    date: Temporal.PlainDate.from("2017-03-01"),
+    timestamp: utcDate("2017-03-01"),
     from: { symbol: "A", amount: 50 },
     to: { symbol: "B", amount: 25, unitPriceEur: 15 },
   },
@@ -30,11 +29,7 @@ const initialLedger: Ledger = [
 
 test("Example 1.1", (t) => {
   t.is(
-    calculateGains(
-      Temporal.PlainDate.from("2016-12-31"),
-      Temporal.PlainDate.from("2017-03-01"),
-      initialLedger
-    ),
+    calculateGains(utcDate("2016-12-31"), utcDate("2017-03-01"), initialLedger),
     125
   )
 })
@@ -43,18 +38,14 @@ const ledger2: Ledger = [
   ...initialLedger,
   {
     id: "4",
-    date: Temporal.PlainDate.from("2017-04-01"),
+    timestamp: utcDate("2017-04-01"),
     from: { symbol: "B", unitPriceEur: 10, amount: 10 },
     to: { symbol: "C", amount: 30 },
   },
 ]
 test("Example 1.2", (t) => {
   t.is(
-    calculateGains(
-      Temporal.PlainDate.from("2017-03-01"),
-      Temporal.PlainDate.from("2017-04-01"),
-      ledger2
-    ),
+    calculateGains(utcDate("2017-03-01"), utcDate("2017-04-01"), ledger2),
     -50
   )
 })
@@ -63,7 +54,7 @@ const ledger3: Ledger = [
   ...ledger2,
   {
     id: "5",
-    date: Temporal.PlainDate.from("2017-05-01"),
+    timestamp: utcDate("2017-05-01"),
     from: { symbol: "B", amount: 15 },
     to: { symbol: "A", amount: 20, unitPriceEur: 20 },
   },
@@ -71,11 +62,7 @@ const ledger3: Ledger = [
 
 test("Example 1.3", (t) => {
   t.is(
-    calculateGains(
-      Temporal.PlainDate.from("2017-04-01"),
-      Temporal.PlainDate.from("2017-05-01"),
-      ledger3
-    ),
+    calculateGains(utcDate("2017-04-01"), utcDate("2017-05-01"), ledger3),
     175
   )
   const result = toComputedLedger(ledger3)
@@ -84,19 +71,19 @@ test("Example 1.3", (t) => {
       {
         amount: 50,
         item: ledger3[0],
-        purchaseDate: Temporal.PlainDate.from("2017-01-01"),
+        purchaseTimestamp: utcDate("2017-01-01"),
         unitPriceEur: 5,
       },
       {
         amount: 100,
         item: ledger3[1],
-        purchaseDate: Temporal.PlainDate.from("2017-02-01"),
+        purchaseTimestamp: utcDate("2017-02-01"),
         unitPriceEur: 10,
       },
       {
         amount: 20,
         item: ledger3[4],
-        purchaseDate: Temporal.PlainDate.from("2017-05-01"),
+        purchaseTimestamp: utcDate("2017-05-01"),
         unitPriceEur: 20,
       },
     ],
@@ -105,30 +92,26 @@ test("Example 1.3", (t) => {
       {
         amount: 30,
         item: ledger3[3],
-        purchaseDate: Temporal.PlainDate.from("2017-04-01"),
+        purchaseTimestamp: utcDate("2017-04-01"),
         unitPriceEur: 100 / 30,
       },
     ],
   }
-  eq(t, result.left, expected)
+  t.deepEqual(result.left, expected)
 })
 
 const ledger4: Ledger = [
   ...ledger3,
   {
     id: "6",
-    date: Temporal.PlainDate.from("2017-08-01"),
+    timestamp: utcDate("2017-08-01"),
     from: { symbol: "A", amount: 100, unitPriceEur: 20 },
     to: { symbol: "EUR", amount: 2_000, unitPriceEur: 1 },
   },
 ]
 test("Example 1.4", (t) => {
   t.is(
-    calculateGains(
-      Temporal.PlainDate.from("2017-05-01"),
-      Temporal.PlainDate.from("2017-08-01"),
-      ledger4
-    ),
+    calculateGains(utcDate("2017-05-01"), utcDate("2017-08-01"), ledger4),
     750 + 500
   )
 })

--- a/ledger/src/example2.test.ts
+++ b/ledger/src/example2.test.ts
@@ -1,6 +1,6 @@
 import test from "ava"
-import { Temporal } from "proposal-temporal"
 import { calculateGains, Ledger } from "."
+import { utcDate } from "./testutils"
 
 // Sourced from:
 // https://www.vero.fi/en/detailed-guidance/guidance/48411/taxation-of-virtual-currencies3/#:~:text=Example%202
@@ -8,13 +8,13 @@ import { calculateGains, Ledger } from "."
 const initialLedger: Ledger = [
   {
     id: "1",
-    date: Temporal.PlainDate.from("2020-01-01"),
+    timestamp: utcDate("2020-01-01"),
     from: { amount: 1_000, symbol: "EUR", unitPriceEur: 1 },
     to: { amount: 200, symbol: "A", unitPriceEur: 5 },
   },
   {
     id: "2",
-    date: Temporal.PlainDate.from("2020-02-01"),
+    timestamp: utcDate("2020-02-01"),
     from: { amount: 100, symbol: "A", unitPriceEur: 10 },
     to: { amount: 1_000, symbol: "EUR", unitPriceEur: 1 },
   },
@@ -22,11 +22,7 @@ const initialLedger: Ledger = [
 
 test("Example 2.1", (t) => {
   t.is(
-    calculateGains(
-      Temporal.PlainDate.from("2019-12-31"),
-      Temporal.PlainDate.from("2020-02-01"),
-      initialLedger
-    ),
+    calculateGains(utcDate("2019-12-31"), utcDate("2020-02-01"), initialLedger),
     500
   )
 })

--- a/ledger/src/example3.test.ts
+++ b/ledger/src/example3.test.ts
@@ -1,7 +1,6 @@
 import test from "ava"
-import { Temporal } from "proposal-temporal"
 import { calculateGains, Ledger } from "."
-import { eq } from "./testutils"
+import { eq, utcDate } from "./testutils"
 import { toComputedLedger } from "./to-computed-ledger"
 
 // Sourced from:
@@ -10,13 +9,13 @@ import { toComputedLedger } from "./to-computed-ledger"
 const initialLedger: Ledger = [
   {
     id: "1",
-    date: Temporal.PlainDate.from("2020-01-01"),
+    timestamp: utcDate("2020-01-01"),
     from: { amount: 10_000, symbol: "EUR", unitPriceEur: 1 },
     to: { amount: 10, symbol: "B", unitPriceEur: 1_000 },
   },
   {
     id: "2",
-    date: Temporal.PlainDate.from("2020-02-01"),
+    timestamp: utcDate("2020-02-01"),
     from: { amount: 1, symbol: "B", unitPriceEur: 500 },
     to: { amount: 500, symbol: "EUR", unitPriceEur: 1 },
   },
@@ -24,11 +23,7 @@ const initialLedger: Ledger = [
 
 test("Example 3.1", (t) => {
   t.is(
-    calculateGains(
-      Temporal.PlainDate.from("2019-12-31"),
-      Temporal.PlainDate.from("2020-02-01"),
-      initialLedger
-    ),
+    calculateGains(utcDate("2019-12-31"), utcDate("2020-02-01"), initialLedger),
     -500
   )
 
@@ -36,7 +31,7 @@ test("Example 3.1", (t) => {
     {
       item: initialLedger[0],
       amount: 9,
-      purchaseDate: Temporal.PlainDate.from("2020-01-01"),
+      purchaseTimestamp: utcDate("2020-01-01"),
       unitPriceEur: 1000,
     },
   ])
@@ -46,7 +41,7 @@ const ledger2: Ledger = [
   ...initialLedger,
   {
     id: "3",
-    date: Temporal.PlainDate.from("2020-03-01"),
+    timestamp: utcDate("2020-03-01"),
     from: { symbol: "B", amount: 9, unitPriceEur: 10_000 },
     to: { symbol: "EUR", amount: 90_000, unitPriceEur: 1 },
     fee: { symbol: "EUR", amount: 1_000, unitPriceEur: 1 },
@@ -55,11 +50,7 @@ const ledger2: Ledger = [
 
 test("Example 3.2", (t) => {
   t.is(
-    calculateGains(
-      Temporal.PlainDate.from("2020-02-01"),
-      Temporal.PlainDate.from("2020-03-01"),
-      ledger2
-    ),
+    calculateGains(utcDate("2020-02-01"), utcDate("2020-03-01"), ledger2),
     72_000
   )
 })
@@ -68,7 +59,7 @@ const ledger2_10YearVersion: Ledger = [
   ...initialLedger,
   {
     id: "4",
-    date: Temporal.PlainDate.from("2030-03-01"),
+    timestamp: utcDate("2030-03-01"),
     from: { symbol: "B", amount: 9, unitPriceEur: 10_000 },
     to: { symbol: "EUR", amount: 90_000, unitPriceEur: 1 },
     fee: { symbol: "EUR", amount: 1_000, unitPriceEur: 1 },
@@ -78,8 +69,8 @@ const ledger2_10YearVersion: Ledger = [
 test("Example 3.2, but hold for over 10 years", (t) => {
   t.is(
     calculateGains(
-      Temporal.PlainDate.from("2020-02-01"),
-      Temporal.PlainDate.from("2030-03-01"),
+      utcDate("2020-02-01"),
+      utcDate("2030-03-01"),
       ledger2_10YearVersion
     ),
     54_000

--- a/ledger/src/example4.test.ts
+++ b/ledger/src/example4.test.ts
@@ -1,7 +1,6 @@
 import test from "ava"
-import { Temporal } from "proposal-temporal"
 import { calculateGains, Ledger } from "."
-import { toComputedLedger } from "./to-computed-ledger"
+import { utcDate } from "./testutils"
 
 // Sourced from:
 // https://www.vero.fi/en/detailed-guidance/guidance/48411/taxation-of-virtual-currencies3/#:~:text=Example%204
@@ -9,13 +8,13 @@ import { toComputedLedger } from "./to-computed-ledger"
 const initialLedger: Ledger = [
   {
     id: "1",
-    date: Temporal.PlainDate.from("2020-01-01"),
+    timestamp: utcDate("2020-01-01"),
     from: { amount: 5_000, symbol: "EUR", unitPriceEur: 1 },
     to: { amount: 1, symbol: "BTC", unitPriceEur: 5_000 },
   },
   {
     id: "2",
-    date: Temporal.PlainDate.from("2020-02-01"),
+    timestamp: utcDate("2020-02-01"),
     from: { amount: 1, symbol: "BTC", unitPriceEur: 4_000 },
     to: { amount: 10, symbol: "B" },
   },
@@ -23,11 +22,7 @@ const initialLedger: Ledger = [
 
 test("Example 4.1", (t) => {
   t.is(
-    calculateGains(
-      Temporal.PlainDate.from("2019-12-31"),
-      Temporal.PlainDate.from("2020-02-01"),
-      initialLedger
-    ),
+    calculateGains(utcDate("2019-12-31"), utcDate("2020-02-01"), initialLedger),
     -1_000
   )
 })
@@ -36,28 +31,21 @@ const ledger2: Ledger = [
   ...initialLedger,
   {
     id: "3",
-    date: Temporal.PlainDate.from("2020-03-01"),
+    timestamp: utcDate("2020-03-01"),
     from: { amount: 10, symbol: "B" },
     to: { amount: 4, symbol: "C" },
   },
 ]
 
 test("Example 4.2", (t) => {
-  t.is(
-    calculateGains(
-      Temporal.PlainDate.from("2020-02-01"),
-      Temporal.PlainDate.from("2020-03-01"),
-      ledger2
-    ),
-    0
-  )
+  t.is(calculateGains(utcDate("2020-02-01"), utcDate("2020-03-01"), ledger2), 0)
 })
 
 const ledger3: Ledger = [
   ...ledger2,
   {
     id: "4",
-    date: Temporal.PlainDate.from("2020-04-01"),
+    timestamp: utcDate("2020-04-01"),
     from: { amount: 4, symbol: "C" },
     to: { amount: 1, symbol: "BTC", unitPriceEur: 7_000 },
   },
@@ -65,11 +53,7 @@ const ledger3: Ledger = [
 
 test("Example 4.3", (t) => {
   t.is(
-    calculateGains(
-      Temporal.PlainDate.from("2020-03-01"),
-      Temporal.PlainDate.from("2020-04-01"),
-      ledger3
-    ),
+    calculateGains(utcDate("2020-03-01"), utcDate("2020-04-01"), ledger3),
     3_000
   )
 })

--- a/ledger/src/testutils.ts
+++ b/ledger/src/testutils.ts
@@ -5,3 +5,5 @@ export const eq = <T>(t: ExecutionContext<unknown>, left: T, right: T) =>
     JSON.parse(JSON.stringify(left)),
     JSON.parse(JSON.stringify(right))
   )
+
+export const utcDate = (date: string) => Date.parse(date)

--- a/ledger/src/to-computed-ledger.test.ts
+++ b/ledger/src/to-computed-ledger.test.ts
@@ -1,7 +1,6 @@
 import test from "ava"
-import { Temporal } from "proposal-temporal"
 import { Ledger, LedgerItem } from "."
-import { eq } from "./testutils"
+import { eq, utcDate } from "./testutils"
 import { toComputedLedger } from "./to-computed-ledger"
 
 test("returns empty ledger passed empty ledger", (t) => {
@@ -11,7 +10,7 @@ test("returns empty ledger passed empty ledger", (t) => {
 test("returns ledger item with no gains on single ledger item", (t) => {
   const item: LedgerItem = {
     id: "123",
-    date: Temporal.PlainDate.from("2020-01-01"),
+    timestamp: utcDate("2020-01-01"),
     from: { symbol: "EUR", amount: 1, unitPriceEur: 1 },
     to: { amount: 10, symbol: "A", unitPriceEur: 0.1 },
   }
@@ -19,7 +18,14 @@ test("returns ledger item with no gains on single ledger item", (t) => {
     consumed: { "123": [] },
     ledger: [{ ...item, taxableGain: 0 }],
     left: {
-      A: [{ amount: 10, item, purchaseDate: item.date, unitPriceEur: 0.1 }],
+      A: [
+        {
+          amount: 10,
+          item,
+          purchaseTimestamp: item.timestamp,
+          unitPriceEur: 0.1,
+        },
+      ],
     },
   })
 })
@@ -27,13 +33,13 @@ test("returns ledger item with no gains on single ledger item", (t) => {
 test("calculates gains from one full back-forth purchase", (t) => {
   const from: LedgerItem = {
     id: "123",
-    date: Temporal.PlainDate.from("2020-01-01"),
+    timestamp: utcDate("2020-01-01"),
     from: { symbol: "EUR", amount: 1, unitPriceEur: 1 },
     to: { amount: 10, symbol: "A", unitPriceEur: 0.1 },
   }
   const to: LedgerItem = {
     id: "124",
-    date: Temporal.PlainDate.from("2020-01-02"),
+    timestamp: utcDate("2020-01-02"),
     from: { amount: 10, symbol: "A", unitPriceEur: 0.2 },
     to: { symbol: "EUR", amount: 2, unitPriceEur: 1 },
   }
@@ -52,13 +58,13 @@ test("calculates gains from one full back-forth purchase", (t) => {
 test("calculates gains from half back-forth purchase", (t) => {
   const from: LedgerItem = {
     id: "123",
-    date: Temporal.PlainDate.from("2020-01-01"),
+    timestamp: utcDate("2020-01-01"),
     from: { symbol: "EUR", amount: 1, unitPriceEur: 1 },
     to: { amount: 10, symbol: "A", unitPriceEur: 0.1 },
   }
   const to: LedgerItem = {
     id: "124",
-    date: Temporal.PlainDate.from("2020-01-02"),
+    timestamp: utcDate("2020-01-02"),
     from: { amount: 5, symbol: "A", unitPriceEur: 0.2 },
     to: { symbol: "EUR", amount: 1, unitPriceEur: 1 },
   }
@@ -80,7 +86,12 @@ test("calculates gains from half back-forth purchase", (t) => {
     ],
     left: {
       A: [
-        { amount: 5, item: from, purchaseDate: from.date, unitPriceEur: 0.1 },
+        {
+          amount: 5,
+          item: from,
+          purchaseTimestamp: from.timestamp,
+          unitPriceEur: 0.1,
+        },
       ],
     },
   })
@@ -89,13 +100,13 @@ test("calculates gains from half back-forth purchase", (t) => {
 test("Reduces all selling fees from gains when selling full amount", (t) => {
   const from: LedgerItem = {
     id: "123",
-    date: Temporal.PlainDate.from("2020-01-01"),
+    timestamp: utcDate("2020-01-01"),
     from: { symbol: "EUR", amount: 1, unitPriceEur: 1 },
     to: { amount: 10, symbol: "A", unitPriceEur: 0.1 },
   }
   const to: LedgerItem = {
     id: "124",
-    date: Temporal.PlainDate.from("2020-01-02"),
+    timestamp: utcDate("2020-01-02"),
     from: { amount: 10, symbol: "A", unitPriceEur: 0.2 },
     to: { symbol: "EUR", amount: 2, unitPriceEur: 1 },
     fee: { symbol: "EUR", amount: 0.1, unitPriceEur: 1 },
@@ -116,14 +127,14 @@ test("Reduces all selling fees from gains when selling full amount", (t) => {
 test("Reduces all selling fees + all purchase fees from gains when selling full amount", (t) => {
   const from: LedgerItem = {
     id: "123",
-    date: Temporal.PlainDate.from("2020-01-01"),
+    timestamp: utcDate("2020-01-01"),
     from: { symbol: "EUR", amount: 1, unitPriceEur: 1 },
     to: { amount: 10, symbol: "A", unitPriceEur: 0.1 },
     fee: { symbol: "EUR", amount: 0.1, unitPriceEur: 1 },
   }
   const to: LedgerItem = {
     id: "124",
-    date: Temporal.PlainDate.from("2020-01-02"),
+    timestamp: utcDate("2020-01-02"),
     from: { amount: 10, symbol: "A", unitPriceEur: 0.2 },
     to: { symbol: "EUR", amount: 2, unitPriceEur: 1 },
     fee: { symbol: "EUR", amount: 0.1, unitPriceEur: 1 },
@@ -144,14 +155,14 @@ test("Reduces all selling fees + all purchase fees from gains when selling full 
 test("Reduces all selling fees + partial of purchase fees from gains when selling partial amount", (t) => {
   const from: LedgerItem = {
     id: "123",
-    date: Temporal.PlainDate.from("2020-01-01"),
+    timestamp: utcDate("2020-01-01"),
     from: { symbol: "EUR", amount: 1, unitPriceEur: 1 },
     to: { amount: 10, symbol: "A", unitPriceEur: 0.1 },
     fee: { symbol: "EUR", amount: 0.1, unitPriceEur: 1 },
   }
   const to: LedgerItem = {
     id: "124",
-    date: Temporal.PlainDate.from("2020-01-02"),
+    timestamp: utcDate("2020-01-02"),
     from: { amount: 5, symbol: "A", unitPriceEur: 0.2 },
     to: { symbol: "EUR", amount: 1, unitPriceEur: 1 },
     fee: { symbol: "EUR", amount: 0.1, unitPriceEur: 1 },
@@ -180,7 +191,7 @@ test("Reduces all selling fees + partial of purchase fees from gains when sellin
         {
           amount: 5,
           item: from,
-          purchaseDate: from.date,
+          purchaseTimestamp: from.timestamp,
           unitPriceEur: 0.1,
         },
       ],
@@ -191,21 +202,21 @@ test("Reduces all selling fees + partial of purchase fees from gains when sellin
 test("Reduces all selling fees + partial of last purchase fee + all of first purchase fee from gains when selling partial amount of two purchases", (t) => {
   const from1: LedgerItem = {
     id: "123",
-    date: Temporal.PlainDate.from("2020-01-01"),
+    timestamp: utcDate("2020-01-01"),
     from: { symbol: "EUR", amount: 10, unitPriceEur: 1 },
     to: { amount: 10, symbol: "A", unitPriceEur: 1 },
     fee: { symbol: "EUR", amount: 1, unitPriceEur: 1 },
   }
   const from2: LedgerItem = {
     id: "124",
-    date: Temporal.PlainDate.from("2020-01-02"),
+    timestamp: utcDate("2020-01-02"),
     from: { symbol: "EUR", amount: 20, unitPriceEur: 1 },
     to: { amount: 10, symbol: "A", unitPriceEur: 2 },
     fee: { symbol: "EUR", amount: 1, unitPriceEur: 1 },
   }
   const to: LedgerItem = {
     id: "125",
-    date: Temporal.PlainDate.from("2020-01-03"),
+    timestamp: utcDate("2020-01-03"),
     from: { amount: 16, symbol: "A", unitPriceEur: 2.5 },
     to: { symbol: "EUR", amount: 40, unitPriceEur: 1 },
     fee: { symbol: "EUR", amount: 1.6, unitPriceEur: 1 },
@@ -267,7 +278,7 @@ test("Reduces all selling fees + partial of last purchase fee + all of first pur
         {
           amount: 4,
           item: from2,
-          purchaseDate: from2.date,
+          purchaseTimestamp: from2.timestamp,
           unitPriceEur: from2.to.unitPriceEur!,
         },
       ],
@@ -278,21 +289,21 @@ test("Reduces all selling fees + partial of last purchase fee + all of first pur
 test("Does not reduce fees if unitPriceEur is not known", (t) => {
   const from: LedgerItem = {
     id: "123",
-    date: Temporal.PlainDate.from("2020-01-01"),
+    timestamp: utcDate("2020-01-01"),
     from: { symbol: "EUR", amount: 1, unitPriceEur: 1 },
     to: { amount: 10, symbol: "A", unitPriceEur: 0.1 },
     fee: { amount: 100, symbol: "C" },
   }
   const to1: LedgerItem = {
     id: "124",
-    date: Temporal.PlainDate.from("2020-01-02"),
+    timestamp: utcDate("2020-01-02"),
     from: { amount: 5, symbol: "A", unitPriceEur: 0.2 },
     to: { symbol: "EUR", amount: 1, unitPriceEur: 1 },
     fee: { symbol: "B", amount: 0.01, unitPriceEur: 5 },
   }
   const to2: LedgerItem = {
     id: "125",
-    date: Temporal.PlainDate.from("2020-01-03"),
+    timestamp: utcDate("2020-01-03"),
     from: { amount: 5, symbol: "A", unitPriceEur: 0.2 },
     to: { symbol: "EUR", amount: 1, unitPriceEur: 1 },
     fee: { symbol: "B", amount: 0.01, unitPriceEur: 5 },
@@ -327,13 +338,13 @@ test("Throws an error if trying to sell nonexisting coins", (t) => {
   const ledger: Ledger = [
     {
       id: "123",
-      date: Temporal.PlainDate.from("2020-01-01"),
+      timestamp: utcDate("2020-01-01"),
       from: { symbol: "EUR", amount: 1, unitPriceEur: 1 },
       to: { symbol: "A", amount: 10 },
     },
     {
       id: "124",
-      date: Temporal.PlainDate.from("2020-01-02"),
+      timestamp: utcDate("2020-01-02"),
       from: { symbol: "A", amount: 20 },
       to: { symbol: "EUR", amount: 100, unitPriceEur: 1 },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -687,11 +687,6 @@ base64-js@^1.0.2, base64-js@^1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-big-integer@^1.6.48:
-  version "1.6.51"
-  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
-  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
-
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -1276,6 +1271,11 @@ data-uri-to-buffer@3.0.1:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
   integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
 
+date-fns@^2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+
 date-time@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/date-time/-/date-time-3.1.0.tgz#0d1e934d170579f481ed8df1e2b8ff70ee845e1e"
@@ -1496,7 +1496,7 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.18.0-next.1, es-abstract@^1.18.5, es-abstract@^1.19.1, es-abstract@^1.19.2:
+es-abstract@^1.18.5, es-abstract@^1.19.1, es-abstract@^1.19.2:
   version "1.19.5"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.5.tgz#a2cb01eb87f724e815b278b0dd0d00f36ca9a7f1"
   integrity sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==
@@ -3392,14 +3392,6 @@ prop-types@^15.7.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
-
-proposal-temporal@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/proposal-temporal/-/proposal-temporal-0.8.0.tgz#6787b49d187e9245d38e7b58d028fd1c84dd14b0"
-  integrity sha512-Ho2uZqtuK310ptV//us50nJIe0Yja1g2LI9zDG9eNDV+oo5DmNqT+zXz6jEVbsZHMa+qSD/FfT776eI64bfuRA==
-  dependencies:
-    big-integer "^1.6.48"
-    es-abstract "^1.18.0-next.1"
 
 public-encrypt@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
The libraary used was deprecated, and caused much more issues than it solved. Using Unix timestamps now to avoid ambiquity.

Fixes #23
Fixes #4